### PR TITLE
moved old types to the bottom

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -30,40 +30,6 @@ export enum Season {
 }
 
 /**
- * Describes a completed Course with all of the course information provided by the Northeastern degree audit.
- * @param hon - True if this course is Honors, false otherwise.
- * @param subject - The subject of this course (such as Computer Science - "CS" - or Psychology)
- * @param classId - The number used to identify the course along with the subject.
- * @param name - The unique name of this course.
- * @param creditHours - The number of credit hours this course is worth.
- * @param season - The season during which this course was taken.
- * @param year - The year during which this course was taken.
- * @param termId - Northeastern's identifier for the term during which this course was taken.
- */
-export interface ICompleteCourse {
-  hon: boolean;
-  subject: string;
-  classId: number;
-  name: string;
-  creditHours: number;
-  season: Season;
-  year: number;
-  termId: number;
-}
-
-/**
- * A catch-all interface for the old requirement format.
- * todo: This will be replaced with the future representations (found below).
- */
-export interface IOldRequirement {
-  classId: number;
-  subject?: string;
-  num_required?: number;
-  classId2?: number;
-  list?: number[];
-}
-
-/**
  * Represents a degree requirement that has not yet been satisfied.
  */
 export type Requirement =
@@ -127,103 +93,6 @@ export interface IRequiredCourse {
 }
 
 /**
- * Represents an initial schedule representation as crafted via the degree audit.
- * @param completed - The completed courses and NUPaths.
- * @param inprogress - The in-progress courses and NUPaths.
- * @param requirements - The requirements for courses and NUPaths yet to be satisfied.
- * @param data - Supplemental information about the student's academic path.
- * @param majors - The major(s) the student intends to obtain degrees for.
- * @param minors - The minor(s) the student intends to obtain.
- * @param auditYear - The year the degree audit was created.
- * @param gradDate - The expected graduation date of the student.
- * @param nupaths - The NUPaths required or satisfied.
- * @param courses - The courses required or satisfied.
- */
-export interface IInitialScheduleRep {
-  completed: {
-    nupaths: NUPath[];
-    courses: ICompleteCourse[];
-  };
-  inprogress: {
-    courses: ICompleteCourse[];
-    nupaths: NUPath[];
-  };
-  requirements: {
-    courses: IOldRequirement[];
-    nupaths: NUPath[];
-  };
-  data: {
-    majors: string[];
-    minors: string[];
-    auditYear: number;
-    gradDate: Date;
-  };
-}
-
-// json_loader.ts types for ScheduleNEU json file reading.
-
-/**
- * Represents an object containing a bunch of child classMaps.
- * Additionally contains classMaps, under property <termId>. Value of type INEUClassMap.
- * @param mostRecentSemester The most recent termId (relative to the present).
- * @param allTermIds A list of all the termIds contained in the intermediate map object.
- */
-export interface INEUParentMap {
-  mostRecentSemester: number;
-  allTermIds: number[];
-  classMapMap: { [key: string]: INEUClassMap };
-}
-
-/**
- * A SearchNEU-style classMap. Holds course data for a certain termId.
- * Keys are in format: "neu.edu/<termId>/<subject>/<classId>" with value type INEUCourse.
- * Contains additional misc. information. See raw JSON.
- * @param termId The termId of this term.
- */
-export interface INEUClassMap {
-  termId: number;
-  classMap: { [key: string]: INEUCourse };
-}
-
-/**
- * A SearchNEU-style course, holding verbose information.
- * @param crns A list of the CRNS of the course.
- * @param prereqs A prereq object, if the course has prereqs.
- * @param coreqs A prereq object, if hte course has coreqs.
- * @param maxCredits The max credits available for this course.
- * @param minCredits The min credits available for this course.
- * @param desc A description of the course.
- * @param classId The course #.
- * @param prettyUrl A URL to a pretty version of the course info.
- * @param name The name of the course.
- * @param url A URL to the course info.
- * @param lastUpdateTime The last time the course was updated.
- * @param termId The term id of the course. Format <4digityear><season>.
- * @param host The host domain.
- * @param subject The subject of the course.
- * @param optPrereqsFor Courses that this course is an optional prerequisite for.
- * @param prereqsFor Courses that this course is a prerequisite for.
- */
-export interface INEUCourse {
-  crns: string[];
-  prereqs?: INEUAndPrereq | INEUOrPrereq;
-  coreqs?: INEUAndPrereq | INEUOrPrereq;
-  maxCredits: number;
-  minCredits: number;
-  desc: string;
-  classId: number;
-  prettyUrl: string;
-  name: string;
-  url: string;
-  lastUpdateTime: number;
-  termId: number;
-  host: string;
-  subject: string;
-  optPrereqsFor?: INEUPrereqCourse[];
-  prereqsFor?: INEUPrereqCourse[];
-}
-
-/**
  * A SearchNEU prerequisite object.
  */
 export type INEUPrereq = INEUAndPrereq | INEUOrPrereq | INEUPrereqCourse;
@@ -258,36 +127,6 @@ export interface INEUPrereqCourse {
   subject: string;
   missing?: true;
 }
-
-// types for json_parser.ts
-
-/**
- * A Schedule.
- * @param completed The completed courses.
- * @param scheduled The scheduled courses.
- */
-export interface ISchedule {
-  completed: ICompleteCourse[];
-  scheduled: string[][];
-  // todo: scheduled: IScheduleCourse[][];
-}
-
-/**
- * A scheduled course.
- * @param classId The course number of the scheduled course.
- * @param subject The subject of the scheduled course.
- */
-export interface IScheduleCourse {
-  classId: number;
-  subject: string;
-}
-
-// types for json_converter.ts
-
-/**
- * A UserChoice is one of OR or RANGE.
- */
-export type UserChoice = ICourseRange | IOrCourse;
 
 // types added for new data representation stuff.
 
@@ -432,3 +271,172 @@ export interface CourseTakenTracker {
   addCourses: (toAdd: string[]) => void;
   addCourse: (toAdd: string) => void;
 }
+
+/** ------------------------------------------------------------------------
+ *
+ *            OLD STUFF FOLLOWS ! This stuff is big outdated and is only
+ *    used by the json converter, loader, and parser, and html parser.
+ *
+ *  -------------------------------------------------------------------------
+ */
+
+/**
+ * Describes a completed Course with all of the course information provided by the Northeastern degree audit.
+ * @param hon - True if this course is Honors, false otherwise.
+ * @param subject - The subject of this course (such as Computer Science - "CS" - or Psychology)
+ * @param classId - The number used to identify the course along with the subject.
+ * @param name - The unique name of this course.
+ * @param creditHours - The number of credit hours this course is worth.
+ * @param season - The season during which this course was taken.
+ * @param year - The year during which this course was taken.
+ * @param termId - Northeastern's identifier for the term during which this course was taken.
+ */
+export interface ICompleteCourse {
+  hon: boolean;
+  subject: string;
+  classId: number;
+  name: string;
+  creditHours: number;
+  season: Season;
+  year: number;
+  termId: number;
+}
+
+/**
+ * A catch-all interface for the old requirement format.
+ * todo: This will be replaced with the future representations (found below).
+ */
+export interface IOldRequirement {
+  classId: number;
+  subject?: string;
+  num_required?: number;
+  classId2?: number;
+  list?: number[];
+}
+
+/**
+ * Represents an initial schedule representation as crafted via the degree audit.
+ * @param completed - The completed courses and NUPaths.
+ * @param inprogress - The in-progress courses and NUPaths.
+ * @param requirements - The requirements for courses and NUPaths yet to be satisfied.
+ * @param data - Supplemental information about the student's academic path.
+ * @param majors - The major(s) the student intends to obtain degrees for.
+ * @param minors - The minor(s) the student intends to obtain.
+ * @param auditYear - The year the degree audit was created.
+ * @param gradDate - The expected graduation date of the student.
+ * @param nupaths - The NUPaths required or satisfied.
+ * @param courses - The courses required or satisfied.
+ */
+export interface IInitialScheduleRep {
+  completed: {
+    nupaths: NUPath[];
+    courses: ICompleteCourse[];
+  };
+  inprogress: {
+    courses: ICompleteCourse[];
+    nupaths: NUPath[];
+  };
+  requirements: {
+    courses: IOldRequirement[];
+    nupaths: NUPath[];
+  };
+  data: {
+    majors: string[];
+    minors: string[];
+    auditYear: number;
+    gradDate: Date;
+  };
+}
+
+// json_loader.ts types for ScheduleNEU json file reading.
+
+/**
+ * Represents an object containing a bunch of child classMaps.
+ * Additionally contains classMaps, under property <termId>. Value of type INEUClassMap.
+ * @param mostRecentSemester The most recent termId (relative to the present).
+ * @param allTermIds A list of all the termIds contained in the intermediate map object.
+ */
+export interface INEUParentMap {
+  mostRecentSemester: number;
+  allTermIds: number[];
+  classMapMap: { [key: string]: INEUClassMap };
+}
+
+/**
+ * A SearchNEU-style classMap. Holds course data for a certain termId.
+ * Keys are in format: "neu.edu/<termId>/<subject>/<classId>" with value type INEUCourse.
+ * Contains additional misc. information. See raw JSON.
+ * @param termId The termId of this term.
+ */
+export interface INEUClassMap {
+  termId: number;
+  classMap: { [key: string]: INEUCourse };
+}
+
+/**
+ * A SearchNEU-style course, holding verbose information.
+ * @param crns A list of the CRNS of the course.
+ * @param prereqs A prereq object, if the course has prereqs.
+ * @param coreqs A prereq object, if hte course has coreqs.
+ * @param maxCredits The max credits available for this course.
+ * @param minCredits The min credits available for this course.
+ * @param desc A description of the course.
+ * @param classId The course #.
+ * @param prettyUrl A URL to a pretty version of the course info.
+ * @param name The name of the course.
+ * @param url A URL to the course info.
+ * @param lastUpdateTime The last time the course was updated.
+ * @param termId The term id of the course. Format <4digityear><season>.
+ * @param host The host domain.
+ * @param subject The subject of the course.
+ * @param optPrereqsFor Courses that this course is an optional prerequisite for.
+ * @param prereqsFor Courses that this course is a prerequisite for.
+ */
+export interface INEUCourse {
+  crns: string[];
+  prereqs?: INEUAndPrereq | INEUOrPrereq;
+  coreqs?: INEUAndPrereq | INEUOrPrereq;
+  maxCredits: number;
+  minCredits: number;
+  desc: string;
+  classId: number;
+  prettyUrl: string;
+  name: string;
+  url: string;
+  lastUpdateTime: number;
+  termId: number;
+  host: string;
+  subject: string;
+  optPrereqsFor?: INEUPrereqCourse[];
+  prereqsFor?: INEUPrereqCourse[];
+}
+
+// types for json_parser.ts
+
+/**
+ * A Schedule.
+ * @param completed The completed courses.
+ * @param scheduled The scheduled courses.
+ */
+export interface ISchedule {
+  completed: ICompleteCourse[];
+  scheduled: string[][];
+  // todo: scheduled: IScheduleCourse[][];
+}
+
+/**
+ * A scheduled course.
+ * @param classId The course number of the scheduled course.
+ * @param subject The subject of the scheduled course.
+ */
+export interface IScheduleCourse {
+  classId: number;
+  subject: string;
+}
+
+// types for json_converter.ts
+
+/**
+ * A UserChoice is one of OR or RANGE.
+ */
+export type UserChoice = ICourseRange | IOrCourse;


### PR DESCRIPTION
This PR is for moving all the old types in types.ts to the bottom of the file.

Perhaps in the future, we should put the types in different files to modulate our types.