### PR TITLE
added plan-of-study parser

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,33 +1,35 @@
 {
-    "name": "backend",
-    "version": "1.0.0",
-    "description": "A degree scheduling service for Northeastern students.",
-    "dependencies": {
-        "cross-env": "5.0.5"
-    },
-    "devDependencies": {
-        "@types/jest": "^24.0.18",
-        "@types/node": "^12.7.2",
-        "husky": "^3.0.5",
-        "prettier": "1.18.2",
-        "pretty-quick": "^1.11.1",
-        "typescript": "^3.6.3",
-        "ts-jest": "^24.0.2",
-        "jest": "^24.9.0"
-    },
-    "husky": {
-        "hooks": {
-            "pre-commit": "pretty-quick --staged"
-        }
-    },
-    "jest": {
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ],
-        "transform": {
-            "\\.(ts|tsx)$": "ts-jest"
-        }
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "A degree scheduling service for Northeastern students.",
+  "dependencies": {
+    "cross-env": "5.0.5"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.18",
+    "@types/node": "^12.7.2",
+    "husky": "^3.0.5",
+    "jest": "^24.9.0",
+    "prettier": "1.18.2",
+    "pretty-quick": "^1.11.1",
+    "ts-jest": "^24.0.2",
+    "typescript": "^3.6.3",
+    "@types/cheerio": "^0.22.13",
+    "cheerio": "^1.0.0-rc.3"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
     }
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "\\.(ts|tsx)$": "ts-jest"
+    }
+  }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,16 +6,17 @@
     "cross-env": "5.0.5"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.13",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.2",
+    "cheerio": "^1.0.0-rc.3",
     "husky": "^3.0.5",
     "jest": "^24.9.0",
     "prettier": "1.18.2",
     "pretty-quick": "^1.11.1",
     "ts-jest": "^24.0.2",
     "typescript": "^3.6.3",
-    "@types/cheerio": "^0.22.13",
-    "cheerio": "^1.0.0-rc.3"
+    "request-promise": "^4.2.4"
   },
   "husky": {
     "hooks": {

--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -1,0 +1,239 @@
+import { load } from "cheerio";
+import {
+  Schedule,
+  ScheduleYear,
+  ScheduleCourse,
+  ScheduleTerm,
+  Season,
+  Status,
+} from "./types";
+import { array } from "prop-types";
+
+/**
+ * Produces the {@interface Schedule}s for a given plan of study for a major.
+ * @param link the link to the plan of study to download.
+ */
+export function planOfStudyToSchedule(planofstudy: string): Schedule[] {
+  const $ = load(planofstudy);
+
+  // the list of found schedules.
+  const schedules: Schedule[] = [];
+
+  // for each of the plans, produce a schedule.
+  $(".sc_plangrid tbody").each((planIndex, table) => {
+    schedules.push(buildSchedule($, table));
+  });
+
+  return schedules;
+}
+
+/**
+ * Builds a schedule from the table information.
+ * @param $ the page
+ * @param table the table of stuff to build the schedule from
+ */
+function buildSchedule($: CheerioStatic, table: CheerioElement): Schedule {
+  // what year we're on
+  const years: ScheduleYear[] = [];
+
+  // information for the current year we're parsing
+  const fall: ScheduleCourse[] | Status.COOP | Status.INACTIVE = [];
+  const spring: ScheduleCourse[] | Status.COOP | Status.INACTIVE = [];
+  const summer1: ScheduleCourse[] | Status.COOP | Status.INACTIVE = [];
+  const summer2: ScheduleCourse[] | Status.COOP | Status.INACTIVE = [];
+
+  let totalCredits = "";
+
+  // table elements
+  const tableRows: CheerioElement[] = table.childNodes;
+
+  // for each of the rows, do something.
+  for (const tableRow of tableRows) {
+    // track the table number.
+    const rowClassName = $(tableRow).attr("class");
+
+    // todo: for some reason there are also row elements that aren't even/odd/plangridsum/term/year? figure it out.
+    if (/^odd/.test(rowClassName) || /^even/.test(rowClassName)) {
+      // iterate through the values of the row.
+
+      // is a mutator
+      addCourses($, tableRow.childNodes, fall, spring, summer1, summer2);
+    } else if (/^plangridsum/.test(rowClassName)) {
+      // make a new year with the existing data
+      years.push(
+        buildYear(tableRow.childNodes, fall, spring, summer1, summer2)
+      );
+    } else if (/^plangridtotal/.test(rowClassName)) {
+      totalCredits = $(tableRow)
+        .find("td")
+        .text();
+    }
+  }
+
+  // build the schedule, and return.
+  return buildScheduleFromYears(years, totalCredits);
+}
+
+/**
+ *
+ * @param years
+ * @param totalCredits
+ */
+function buildScheduleFromYears(
+  years: ScheduleYear[],
+  totalCredits: string
+): Schedule {
+  const schedule: Schedule = {
+    years: [],
+    yearMap: {},
+    id: 0,
+  };
+
+  // add each of the years to schedule
+  for (const year of years) {
+    schedule.years.push(year.year);
+    schedule.yearMap[year.year] = year;
+  }
+
+  return schedule;
+}
+
+/**
+ *
+ * @param nodes
+ */
+function addCourses(
+  $: CheerioStatic,
+  nodes: CheerioElement[],
+  fall: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  spring: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  summer1: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  summer2: ScheduleCourse[] | Status.COOP | Status.INACTIVE
+): void {
+  // invariant: there will be exactly 4 codecol and 4 hourscol elements.
+  let cellIndex = 0;
+  let code = "";
+  let hours = "";
+
+  console.log(nodes.length);
+  for (const tableCell of nodes) {
+    console.log(tableCell.attribs);
+
+    if (tableCell.type !== "tag") {
+      continue;
+    }
+
+    const tableCellName = $(tableCell).attr("class");
+    if (/codecol/.test(tableCellName)) {
+      code = $(tableCell).text()
+        ? $(tableCell)
+            .find("a")
+            .text()
+        : $(tableCell).text();
+    } else if (/hourscol/.test(tableCellName)) {
+      hours = $(tableCell).text(); // could be undefined.
+    }
+  }
+}
+
+/**
+ * Adds a row's data to the provided arrays.
+ * @param nodes the course information for the provided row
+ * @param fall the fall data
+ * @param spring the spring data
+ * @param summer1 summer1 data
+ * @param summer2 summer2 data
+ */
+function addCourse(nodes: CheerioElement[]): ScheduleCourse {
+  // invariant: length of nodes is 8.
+  // pattern is codecol, hourscol, codecol, hourscol...
+
+  for (const el of nodes) {
+  }
+
+  return {
+    classId: 2500,
+    subject: "CS",
+    numCreditsMax: 4,
+    numCreditsMin: 4,
+  };
+}
+
+/**
+ * Builds a {@interface ScheduleYear} if data exists, and pushes the it to completed.
+ * @param nodes the childnodes containing the credit information
+ * @param fall the fall data
+ * @param spring the spring data
+ * @param summer1 the summer1 data
+ * @param summer2 the summer2 data
+ */
+function buildYear(
+  nodes: CheerioElement[],
+  fall: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  spring: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  summer1: ScheduleCourse[] | Status.COOP | Status.INACTIVE,
+  summer2: ScheduleCourse[] | Status.COOP | Status.INACTIVE
+): ScheduleYear {
+  const year: ScheduleYear = {
+    fall: {
+      season: Season.FL,
+      termId: 9999,
+      year: 0,
+      id: 0,
+      status: Status.CLASSES,
+      classes: [],
+    },
+    spring: {
+      season: Season.SP,
+      termId: 9999,
+      year: 0,
+      id: 0,
+      status: Status.CLASSES,
+      classes: [],
+    },
+    summer1: {
+      season: Season.S1,
+      termId: 9999,
+      year: 0,
+      id: 0,
+      status: Status.CLASSES,
+      classes: [],
+    },
+    summer2: {
+      season: Season.S2,
+      termId: 9999,
+      year: 0,
+      id: 0,
+      status: Status.CLASSES,
+      classes: [],
+    },
+    year: 0,
+    isSummerFull: false,
+  };
+
+  if (fall === Status.COOP || fall === Status.INACTIVE) {
+    year.fall.status = fall;
+  } else {
+    year.fall.classes = fall;
+  }
+
+  if (spring === Status.COOP || spring === Status.INACTIVE) {
+    year.spring.status = spring;
+  } else {
+    year.spring.classes = spring;
+  }
+
+  if (summer1 === Status.COOP || summer1 === Status.INACTIVE) {
+    year.summer1.status = summer1;
+  } else {
+    year.summer1.classes = summer1;
+  }
+
+  if (summer2 === Status.COOP || summer2 === Status.INACTIVE) {
+    year.summer2.status = summer2;
+  } else {
+    year.summer2.classes = summer2;
+  }
+
+  return year;
+}

--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -7,7 +7,6 @@ import {
   Season,
   Status,
 } from "./types";
-import { array } from "prop-types";
 
 /**
  * Produces the {@interface Schedule}s for a given plan of study for a major.
@@ -45,29 +44,39 @@ function buildSchedule($: CheerioStatic, table: CheerioElement): Schedule {
   let totalCredits = "";
 
   // table elements
-  const tableRows: CheerioElement[] = table.childNodes;
+  const tableRows: CheerioElement[] = [];
+  $(table)
+    .find("tr")
+    .each((index, tableRow) => {
+      // track the table number.
+      const rowClassName = $(tableRow).attr("class");
+
+      // todo: for some reason there are also row elements that aren't even/odd/plangridsum/term/year? figure it out.
+      if (/^odd/.test(rowClassName) || /^even/.test(rowClassName)) {
+        // iterate through the values of the row.
+        const tableCells: CheerioElement[] = [];
+        $(tableRow)
+          .find("td")
+          .each((index, el) => {
+            tableCells.push(el);
+          });
+
+        // is a mutator
+        addCourses($, tableCells, fall, spring, summer1, summer2);
+      } else if (/^plangridsum/.test(rowClassName)) {
+        // make a new year with the existing data
+        years.push(
+          buildYear(tableRow.childNodes, fall, spring, summer1, summer2)
+        );
+      } else if (/^plangridtotal/.test(rowClassName)) {
+        totalCredits = $(tableRow)
+          .find("td")
+          .text();
+      }
+    });
 
   // for each of the rows, do something.
   for (const tableRow of tableRows) {
-    // track the table number.
-    const rowClassName = $(tableRow).attr("class");
-
-    // todo: for some reason there are also row elements that aren't even/odd/plangridsum/term/year? figure it out.
-    if (/^odd/.test(rowClassName) || /^even/.test(rowClassName)) {
-      // iterate through the values of the row.
-
-      // is a mutator
-      addCourses($, tableRow.childNodes, fall, spring, summer1, summer2);
-    } else if (/^plangridsum/.test(rowClassName)) {
-      // make a new year with the existing data
-      years.push(
-        buildYear(tableRow.childNodes, fall, spring, summer1, summer2)
-      );
-    } else if (/^plangridtotal/.test(rowClassName)) {
-      totalCredits = $(tableRow)
-        .find("td")
-        .text();
-    }
   }
 
   // build the schedule, and return.
@@ -117,7 +126,7 @@ function addCourses(
 
   console.log(nodes.length);
   for (const tableCell of nodes) {
-    console.log(tableCell.attribs);
+    //console.log($(tableCell))
 
     if (tableCell.type !== "tag") {
       continue;

--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -175,6 +175,12 @@ function addCourses(
             });
             i += 1;
             break;
+          case "":
+            // There are sometimes random codecols that are blank.
+            produced.push("");
+            // Assume that an hourscol follows, get rid of it too.
+            i += 1;
+            break;
           default:
             // either course, or random elective.
             // if second word is a number, with exactly 2 sections, then we have a course.

--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -266,13 +266,15 @@ function buildYear(
   // iterate over each of the seasons, building up terms.
   for (let i = 0; i < 5; i += 1) {
     if (seasons[i]) {
+      seasons[i] = seasons[i].filter(item => item !== "");
+
       let status: Status;
       // change status depending on what the first string is (invariant).
       if (seasons[i][0] === "Co-op") {
         status = Status.COOP;
-      } else if (seasons[i][0] === "Vacation" || seasons[i][0] === "") {
+      } else if (seasons[i][0] === "Vacation") {
         status = Status.INACTIVE;
-      } else if (seasons[i].length > 1) {
+      } else if (seasons[i].length > 0) {
         status = Status.CLASSES;
       } else {
         // we didn't have anything, so our status is inactive.

--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -92,9 +92,9 @@ function buildScheduleFromYears(
   years = years.map(function(year: ScheduleYear, index: number): ScheduleYear {
     for (const term of [year.fall, year.spring, year.summer1, year.summer2]) {
       // set this one first, uses termId (two digits).
-      term.id = BASE_YEAR * 100 + term.termId + index;
+      term.id = BASE_YEAR + term.termId + index;
       // set this one second, is year shifted two digits left, plus existing termId (one of 10, 30, 40, 60).
-      term.termId = BASE_YEAR * 100 + term.termId;
+      term.termId = (BASE_YEAR + index) * 100 + term.termId;
       // the year is base year plus the index of the year.
       term.year = BASE_YEAR + index;
     }
@@ -129,7 +129,10 @@ function addCourses(
   $(tableRow)
     .find("td")
     .each((index, tableCell) => {
-      const tableCellClass = $(tableCell).attr("class");
+      let tableCellClass = $(tableCell).attr("class");
+      if (tableCellClass) {
+        tableCellClass = tableCellClass.replace(/\s\s+/g, "");
+      }
 
       if (tableCellClass === "codecol") {
         /**
@@ -141,7 +144,10 @@ function addCourses(
          * is Elective
          * some text
          */
-        const tableCellText = $(tableCell).text();
+        let tableCellText = $(tableCell).text();
+        if (tableCellText) {
+          tableCellText = tableCellText.replace(/\s\s+/g, "");
+        }
         if ($(tableCell).find("a")) {
           // has an <a>
           hasCode = true; // has an hours column.
@@ -167,10 +173,13 @@ function addCourses(
         if (hasCode) {
           // we have a code
           hours = $(tableCell).text();
+          if (hours) {
+            hours = hours.replace(/\s\s+g/, "");
+          }
           hasCode = false;
 
           // add the course
-          const subjectAndClassId: string[] = code.split(" ");
+          const subjectAndClassId: string[] = code.split(/\s/);
           produced.push({
             subject: subjectAndClassId[0],
             classId: parseInt(subjectAndClassId[1]),
@@ -178,9 +187,9 @@ function addCourses(
             numCreditsMax: parseInt(hours),
           });
 
-          if (parseInt(subjectAndClassId[1]) === NaN) {
-            throw code;
-          }
+          // if (isNaN(parseInt(subjectAndClassId[1]))) {
+          //   throw "start:" + code + ":" + JSON.stringify(subjectAndClassId) + ":end";
+          // }
         } else {
           // otherwise, we didn't have a course, so just push the item.
           produced.push(code);

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 // tests using BSCS plan of study. downloaded from:
 // "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext"
 
-// test for deep equality
+// test for schedule formation.
 test("Ensures that the pos parser correctly converts the BSCS plan of study.", () => {
   // the plan of study, as plaintext.
   const plaintext = fs.readFileSync(
@@ -14,9 +14,21 @@ test("Ensures that the pos parser correctly converts the BSCS plan of study.", (
 
   // get the schedules.
   const schedules = plan_parser.planOfStudyToSchedule(plaintext);
-  fs.writeFileSync("./schedules.json", JSON.stringify(schedules[0], null, 2));
+  // fs.writeFileSync("./schedules.json", JSON.stringify(schedules[0], null, 2));
 
   // should test every schedule produced.
+  expect(schedules).toBeValidModernScheduleList();
+});
+
+// test for schedule formation.
+test("Ensures that the plan parser correctly converts the BFA Design plan of study.", () => {
+  const plaintext = fs.readFileSync(
+    "./backend/test/Design, BFA < Northeastern University.html",
+    "utf-8"
+  );
+
+  const schedules = plan_parser.planOfStudyToSchedule(plaintext);
+
   expect(schedules).toBeValidModernScheduleList();
 });
 
@@ -105,9 +117,7 @@ expect.extend({
           expect(term.termId).toEqual(
             yearNumber * 100 + seasonIds[seasonsIndex]
           );
-          expect(term.id).toEqual(
-            yearNumber + seasonIds[seasonsIndex] + seasonsIndex
-          );
+          expect(term.id).toEqual(yearNumber + seasonIds[seasonsIndex]);
           expect(term.status).toMatch(/COOP|CLASSES|INACTIVE/);
 
           // classes should be defined.
@@ -139,7 +149,7 @@ expect.extend({
               expect(course).toHaveProperty("numCreditsMax");
 
               // expect some things about each property.
-              expect(course.classId).toBeGreaterThan(1000);
+              expect(course.classId).toBeGreaterThan(999);
               expect(course.subject.length).toBeGreaterThanOrEqual(2);
               expect(course.numCreditsMin).toBeGreaterThan(0);
               expect(course.numCreditsMax).toBeGreaterThan(0);

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -1,35 +1,40 @@
 const plan_parser = require("../src/plan_parser.ts");
 const fs = require("fs");
+const http = require("http");
 
-// tests using BSCS plan of study. downloaded from:
-// "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext"
+// plans of study to run tests on.
+const links = [
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/arts-media-design/art-design/design-bfa/#newitemtext",
+  "http://catalog.northeastern.edu/undergraduate/social-sciences-humanities/english/english-graphic-information-design-ba/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/science/marine-environmental/environmental-science-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/science/marine-environmental/marine-biology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/business/business-administration-bsba/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/engineering/mechanical-industrial/bsme/#planofstudytext",
+];
 
-// test for schedule formation.
-test("Ensures that the pos parser correctly converts the BSCS plan of study.", () => {
-  // the plan of study, as plaintext.
-  const plaintext = fs.readFileSync(
-    "./backend/test/Computer Science, BSCS < Northeastern University.html",
-    "utf-8"
-  );
-
-  // get the schedules.
-  const schedules = plan_parser.planOfStudyToSchedule(plaintext);
-  // fs.writeFileSync("./schedules.json", JSON.stringify(schedules[0], null, 2));
-
-  // should test every schedule produced.
-  expect(schedules).toBeValidModernScheduleList();
+// download all the links async, stored as strings.
+const plans = links.map(link => {
+  return new Promise((resolve, reject) => {
+    http
+      .get(link, response => {
+        resolve(response);
+      })
+      .on("error", err => {
+        reject(err);
+      });
+  });
 });
 
-// test for schedule formation.
-test("Ensures that the plan parser correctly converts the BFA Design plan of study.", () => {
-  const plaintext = fs.readFileSync(
-    "./backend/test/Design, BFA < Northeastern University.html",
-    "utf-8"
+// run tests on the results.
+plans.map((plan, index) => {
+  test(
+    "Ensures that scraper correctly converts plan of study no. " + index,
+    async () => {
+      const schedules = plan_parser.planOfStudyToSchedule(await plan);
+      expect(schedules).toBeValidModernScheduleList();
+    }
   );
-
-  const schedules = plan_parser.planOfStudyToSchedule(plaintext);
-
-  expect(schedules).toBeValidModernScheduleList();
 });
 
 // custom matchers for Jest testing.

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -14,6 +14,7 @@ test("Ensures that the pos parser correctly converts the BSCS plan of study.", (
 
   // get the schedules.
   const schedules = plan_parser.planOfStudyToSchedule(plaintext);
+  fs.writeFileSync("./schedules.json", JSON.stringify(schedules[0], null, 2));
 
   // should test every schedule produced.
   expect(schedules).toBeValidModernScheduleList();
@@ -105,7 +106,7 @@ expect.extend({
             yearNumber * 100 + seasonIds[seasonsIndex]
           );
           expect(term.id).toEqual(
-            yearNumber * 100 + seasonIds[seasonsIndex] + seasonsIndex
+            yearNumber + seasonIds[seasonsIndex] + seasonsIndex
           );
           expect(term.status).toMatch(/COOP|CLASSES|INACTIVE/);
 

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -1,0 +1,19 @@
+const plan_parser = require("../src/plan_parser.ts");
+const fs = require("fs");
+const cheerio = require("cheerio");
+
+// link for BSCS plan of study
+// "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext"
+
+// test for deep equality
+test("Ensures that the pos parser correctly converts the BSCS plan of study.", () => {
+  // the plan of study, as plaintext.
+  const plaintext = fs.readFileSync(
+    "./backend/test/Computer Science, BSCS < Northeastern University.html",
+    "utf-8"
+  );
+
+  const schedules = plan_parser.planOfStudyToSchedule(plaintext);
+
+  expect(true).toBeTruthy();
+});

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -30,9 +30,52 @@ const camd_architecture = [
   // "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/urban-landscape-studies-minor/",
 ];
 
+const khoury = [
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bacs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/cybersecurity/cybersecurity-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/data-science/data-science-bs/#planofstudytext",
+  // combined majors
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-design-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-game-development-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/engineering/electrical-computer/computer-engineering-computer-science-bscompe/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-psychology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-mathematics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-journalism-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-health-science-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-environmental-science-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-ecology-evolutionary-biology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-business-administration-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-behavioral-neuroscience-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-biology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/data-science-biochemistry-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/cybersecurity-economics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/cybersecurity-criminal-justice-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/cybersecurity-business-administration-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-sociology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-political-science-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-physics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-philosophy-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-concentration-music-composition-technology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-media-arts-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-mathematics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-linguistics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-journalism-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-history-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-environmental-science-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-english-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/economics-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-criminal-justice-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-communication-studies-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-cognitive-psychology-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-business-administration-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-information-science-combined-majors/computer-science-biology-bs/#planofstudytext",
+];
+
 // runs tests
 runTestsOnLinks(general);
 runTestsOnLinks(camd_architecture);
+runTestsOnLinks(khoury);
 
 /**
  * Runs tests on an array of links.

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const http = require("http");
 
 // plans of study to run tests on.
-const links = [
+const general = [
   "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext",
   "http://catalog.northeastern.edu/undergraduate/arts-media-design/art-design/design-bfa/#newitemtext",
   "http://catalog.northeastern.edu/undergraduate/social-sciences-humanities/english/english-graphic-information-design-ba/#planofstudytext",
@@ -13,29 +13,55 @@ const links = [
   "http://catalog.northeastern.edu/undergraduate/engineering/mechanical-industrial/bsme/#planofstudytext",
 ];
 
-// download all the links async, stored as strings.
-const plans = links.map(link => {
-  return new Promise((resolve, reject) => {
-    http
-      .get(link, response => {
-        resolve(response);
-      })
-      .on("error", err => {
-        reject(err);
-      });
-  });
-});
+const camd_architecture = [
+  "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architecture-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architectural-studies-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/landscape-architecture-bla/#planofstudytext",
+  // no plan of study available.
+  // "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architecture-english-bs/",
+  "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architecture-graphic-information-design-bs/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/engineering/civil-environmental/civil-engineering-architectural-studies-bsce/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/engineering/civil-environmental/environmental-engineering-landscape-architecture-bsenve/#planofstudytext",
+  "http://catalog.northeastern.edu/undergraduate/science/marine-environmental/environmental-science-landscape-architecture-bs/#planofstudytext",
+  // no plan of study available for minors
+  // "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architectural-history-minor/",
+  // "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/architectural-science-systems-minor/",
+  // "http://catalog.northeastern.edu/undergraduate/arts-media-design/architecture/urban-landscape-studies-minor/",
+];
 
-// run tests on the results.
-plans.map((plan, index) => {
-  test(
-    "Ensures that scraper correctly converts plan of study no. " + index,
-    async () => {
-      const schedules = plan_parser.planOfStudyToSchedule(await plan);
-      expect(schedules).toBeValidModernScheduleList();
-    }
-  );
-});
+// runs tests
+runTestsOnLinks(general);
+runTestsOnLinks(camd_architecture);
+
+/**
+ * Runs tests on an array of links.
+ * @param {string[]} links the links to plans of study to test on.
+ */
+function runTestsOnLinks(links) {
+  // download all the links async, stored as strings.
+  const plans = links.map(link => {
+    return new Promise((resolve, reject) => {
+      http
+        .get(link, response => {
+          resolve(response);
+        })
+        .on("error", err => {
+          reject(err);
+        });
+    });
+  });
+
+  // run tests on the results.
+  plans.map((plan, index) => {
+    test(
+      "Ensures that scraper correctly converts plan of study no. " + index,
+      async () => {
+        const schedules = plan_parser.planOfStudyToSchedule(await plan);
+        expect(schedules).toBeValidModernScheduleList();
+      }
+    );
+  });
+}
 
 // custom matchers for Jest testing.
 expect.extend({

--- a/backend/test/plan_parser.test.js
+++ b/backend/test/plan_parser.test.js
@@ -1,8 +1,7 @@
 const plan_parser = require("../src/plan_parser.ts");
 const fs = require("fs");
-const cheerio = require("cheerio");
 
-// link for BSCS plan of study
+// tests using BSCS plan of study. downloaded from:
 // "http://catalog.northeastern.edu/undergraduate/computer-information-science/computer-science/bscs/#planofstudytext"
 
 // test for deep equality
@@ -13,7 +12,146 @@ test("Ensures that the pos parser correctly converts the BSCS plan of study.", (
     "utf-8"
   );
 
+  // get the schedules.
   const schedules = plan_parser.planOfStudyToSchedule(plaintext);
 
-  expect(true).toBeTruthy();
+  // should test every schedule produced.
+  expect(schedules).toBeValidModernScheduleList();
+});
+
+// custom matchers for Jest testing.
+expect.extend({
+  // custom matcher for checking schedule property form.
+  toBeValidModernScheduleList(received) {
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Array);
+
+    // for each of the schedules, check they are proper.
+    for (
+      let scheduleIndex = 0;
+      scheduleIndex < received.length;
+      scheduleIndex += 1
+    ) {
+      const schedule = received[scheduleIndex];
+
+      // ensure schedule is defined, and is an Object.
+      expect(schedule).toBeDefined();
+      expect(schedule).toBeInstanceOf(Object);
+
+      // ensure that it has all the proper properties (hava) of a {@interface Schedule}.
+      expect(schedule).toHaveProperty("years");
+      expect(schedule).toHaveProperty("yearMap");
+      expect(schedule).toHaveProperty("id");
+
+      // make sure they are of proper tyes
+      expect(schedule.years).toBeInstanceOf(Array);
+      expect(schedule.yearMap).toBeInstanceOf(Object);
+      expect(schedule.id).toEqual(scheduleIndex);
+
+      // all of the years should be properties of yearMap.
+      const yearMap = schedule.yearMap;
+      for (
+        let yearIndex = 0;
+        yearIndex < schedule.years.length;
+        yearIndex += 1
+      ) {
+        const yearNumber = schedule.years[yearIndex];
+
+        // expect year to have isSummerFull and year
+        expect(yearMap).toHaveProperty("" + yearNumber);
+        expect(yearMap[yearNumber]).toBeDefined();
+        expect(yearMap[yearNumber]).toBeInstanceOf(Object);
+
+        const yearObj = yearMap[yearNumber];
+
+        // is defined
+        expect(yearObj).toBeDefined();
+        expect(yearObj).toBeInstanceOf(Object);
+
+        // year object should have a year and a isSummerFull as well as seasons.
+        expect(yearObj).toHaveProperty("year");
+        expect(yearObj).toHaveProperty("isSummerFull");
+
+        expect(yearObj.year).toEqual(yearNumber);
+
+        // expect the year to have several terms.
+        const seasons = ["FL", "SP", "S1", "S2"];
+        const seasonIds = [10, 30, 40, 60];
+        const terms = ["fall", "spring", "summer1", "summer2"];
+        for (
+          let seasonsIndex = 0;
+          seasonsIndex < seasons.length;
+          seasonsIndex += 1
+        ) {
+          expect(yearObj).toHaveProperty(terms[seasonsIndex]);
+          const term = yearObj[terms[seasonsIndex]];
+
+          // should be defined object.
+          expect(term).toBeDefined();
+          expect(term).toBeInstanceOf(Object);
+
+          // property check
+          expect(term).toHaveProperty("season");
+          expect(term).toHaveProperty("year");
+          expect(term).toHaveProperty("termId");
+          expect(term).toHaveProperty("id");
+          expect(term).toHaveProperty("status");
+          expect(term).toHaveProperty("classes");
+
+          // check properties of term.
+          expect(term.season).toEqual(seasons[seasonsIndex]);
+          expect(term.year).toEqual(yearNumber);
+          expect(term.termId).toEqual(
+            yearNumber * 100 + seasonIds[seasonsIndex]
+          );
+          expect(term.id).toEqual(
+            yearNumber * 100 + seasonIds[seasonsIndex] + seasonsIndex
+          );
+          expect(term.status).toMatch(/COOP|CLASSES|INACTIVE/);
+
+          // classes should be defined.
+          expect(term.classes).toBeDefined();
+          expect(term.classes).toBeInstanceOf(Array);
+
+          // check classes length based on status.
+          if (/COOP|INACTIVE/.test(term.status)) {
+            // if we are on coop or inactive, there should be zero courses.
+            expect(term.classes.length).toEqual(0);
+          } else {
+            // we should have courses.
+            expect(term.classes.length).toBeGreaterThan(0);
+
+            for (
+              let classIndex = 0;
+              classIndex < term.classes.length;
+              classIndex += 1
+            ) {
+              // each {@interface ScheduleCourse} should have the correct properties.
+              const course = term.classes[classIndex];
+
+              expect(course).toBeDefined();
+
+              // classId, subject, numCreditsMin, numCreditsMax
+              expect(course).toHaveProperty("classId");
+              expect(course).toHaveProperty("subject");
+              expect(course).toHaveProperty("numCreditsMin");
+              expect(course).toHaveProperty("numCreditsMax");
+
+              // expect some things about each property.
+              expect(course.classId).toBeGreaterThan(1000);
+              expect(course.subject.length).toBeGreaterThanOrEqual(2);
+              expect(course.numCreditsMin).toBeGreaterThan(0);
+              expect(course.numCreditsMax).toBeGreaterThan(0);
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      message: () =>
+        `expected ${received} not to have valid schedule properties.`,
+      pass: true,
+    };
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-bluebird@^3.5.5:
+bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
   integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
@@ -8699,6 +8699,16 @@ request-promise-native@^1.0.5:
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
   integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
   dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
+  dependencies:
+    bluebird "^3.5.0"
     request-promise-core "1.1.2"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,6 +1258,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cheerio@^0.22.13":
+  version "0.22.13"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.13.tgz#5eecda091a24514185dcba99eda77e62bf6523e6"
+  integrity sha512-OZd7dCUOUkiTorf97vJKwZnSja/DmHfuBAroe1kREZZTCf/tlFecwHhsOos3uVHxeKGZDwzolIrCUApClkdLuA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1299,6 +1306,11 @@
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+
+"@types/node@*":
+  version "12.7.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"
+  integrity sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==
 
 "@types/node@^12.7.2":
   version "12.7.9"
@@ -2488,6 +2500,18 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -2999,7 +3023,7 @@ css-select-base-adapter@^0.1.1:
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
   integrity sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
@@ -3449,12 +3473,20 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-domelementtype@1, domelementtype@^1.3.1:
+domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
@@ -3588,7 +3620,7 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
-entities@^1.1.1:
+entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
@@ -4745,7 +4777,7 @@ html-webpack-plugin@4.0.0-beta.5:
     tapable "^1.1.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0:
+htmlparser2@^3.3.0, htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -6159,7 +6191,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7164,6 +7196,13 @@ parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
Added plan-of-study parser. 

Right now I've tested it on all of the CAMD Art+Design majors, as well as some randomly picked majors from other colleges. Could potentially test it on more, would just require pasting in more links to the test suite. Fairly simple to do, I wrote a test function that only requires links.

Notable edge cases:
* some plans only have 3 terms/year
* some plans have 5 terms/year
* some plans label their Co-op terms with a number
* sometimes classes don't have credit numbers.
* some electives have numbers in their name

There are probably more edge cases. Please wait for me to test all of the CS majors at the very minimum.