### PR TITLE
sf->sm

### DIFF
--- a/backend/src/plan_parser.ts
+++ b/backend/src/plan_parser.ts
@@ -271,7 +271,7 @@ function buildYear(
     SeasonEnum.SP,
     SeasonEnum.S1,
     SeasonEnum.S2,
-    SeasonEnum.SF,
+    SeasonEnum.SM,
   ];
   const seasonTermIds: number[] = [10, 30, 40, 60, 50];
   const terms: ScheduleTerm[] = [];

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -26,7 +26,7 @@ export enum SeasonEnum {
   SP = "SP",
   S1 = "S1",
   S2 = "S2",
-  SF = "SF",
+  SM = "SM",
 }
 export type Season = keyof typeof SeasonEnum;
 export type SeasonWord = "fall" | "spring" | "summer1" | "summer2";


### PR DESCRIPTION
Changed SeasonEnum.SF = "SF" to SeasonEnum.SM = "SM" for consistency with degree audit.

To test:
- Ensure that both frontend and backend compile their code properly. (```tsc``` in each)
- Ensure that no functionality has changed with this data definition changed. 

There appears to be no logical change in the code base, and there is no change in the application's functionality - the one place the definition appears to be used places an instance of the enum in an array, then assigns by array index. It is also likely used by the html_parser.ts file but this is long deprecated. 
