### PR TITLE
Completed courses onboarding screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { Provider } from "react-redux";
 import { Store } from "redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { Persistor } from "redux-persist";
+import { CompletedCoursesScreen } from "./Onboarding/CompletedCoursesScreen";
 
 export const App = ({
   store,
@@ -30,6 +31,10 @@ export const App = ({
             <Route path="/graduationYear" component={GraduationYearScreen} />
             <Route path="/major" component={MajorScreen} />
             <Route path="/minors" component={MinorsScreen} />
+            <Route
+              path="/completedCourses"
+              component={CompletedCoursesScreen}
+            />
             <Route path="/" component={Onboarding} />
           </Switch>
         </Router>

--- a/frontend/src/Onboarding/CompletedCoursesScreen.tsx
+++ b/frontend/src/Onboarding/CompletedCoursesScreen.tsx
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { AppState } from "../state/reducers/state";
+import { GenericQuestionTemplate } from "./GenericQuestionScreen";
+import { Dispatch } from "redux";
+import { ScheduleCourse, Major } from "../models/types";
+import { getMajorFromState } from "../state";
+import { addCompletedCourses } from "../state/actions/scheduleActions";
+
+interface Props {
+  major?: Major;
+}
+
+interface State {
+  selectedCourses: ScheduleCourse[];
+}
+
+export class CompletedCoursesComponent extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      selectedCourses: [],
+    };
+  }
+
+  render() {
+    return (
+      <GenericQuestionTemplate question="Which classes have you taken?">
+        <div></div>
+      </GenericQuestionTemplate>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  major: getMajorFromState(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  setCompletedCourses: (completedCourses: ScheduleCourse[]) =>
+    dispatch(addCompletedCourses(completedCourses)),
+});
+
+export const CompletedCoursesScreen = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CompletedCoursesComponent);

--- a/frontend/src/Onboarding/CompletedCoursesScreen.tsx
+++ b/frontend/src/Onboarding/CompletedCoursesScreen.tsx
@@ -1,21 +1,96 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { AppState } from "../state/reducers/state";
-import { GenericQuestionTemplate } from "./GenericQuestionScreen";
 import { Dispatch } from "redux";
-import { ScheduleCourse, Major } from "../models/types";
+import {
+  ScheduleCourse,
+  Major,
+  IRequiredCourse,
+  Requirement,
+  ICourseRange,
+  ISubjectRange,
+} from "../models/types";
 import { getMajorFromState } from "../state";
 import { addCompletedCourses } from "../state/actions/scheduleActions";
+import styled from "styled-components";
+import { Checkbox } from "@material-ui/core";
+import { fetchCourse } from "../api";
+import { NextButton } from "../components/common/NextButton";
+import { Link, withRouter, RouteComponentProps } from "react-router-dom";
 
-interface Props {
-  major?: Major;
+const Wrapper = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  height: 100vh;
+`;
+
+const Box = styled.div`
+  margin-top: 20vh;
+  border: 1px solid black;
+  padding: 18px;
+  width: 500px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Title = styled.h2``;
+
+const Question = styled.p``;
+
+const TitleText = styled.div`
+  margin-left: 4px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+`;
+
+const CourseWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const CourseText = styled.p`
+  font-size: 14px;
+  margin: 4px;
+`;
+
+const CourseTextNoMargin = styled.p`
+  font-size: 14px;
+  margin: 0px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+`;
+
+const CourseAndLabWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  margin-left: 4px;
+`;
+
+const ANDORText = styled.p`
+  font-size: 11px;
+  margin: 4px;
+`;
+
+const BottomSpace = styled.div`
+  margin-bottom: 20vh;
+`;
+
+interface CompletedCoursesScreenProps {
+  major: Major;
+  setCompletedCourses: (completedCourses: ScheduleCourse[]) => void;
 }
+
+type Props = CompletedCoursesScreenProps & RouteComponentProps;
 
 interface State {
   selectedCourses: ScheduleCourse[];
 }
 
-export class CompletedCoursesComponent extends Component<Props, State> {
+class CompletedCoursesComponent extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -24,17 +99,175 @@ export class CompletedCoursesComponent extends Component<Props, State> {
     };
   }
 
+  onSubmit() {
+    this.props.setCompletedCourses(this.state.selectedCourses);
+  }
+
+  async handleChecked(e: any, course: IRequiredCourse) {
+    const checked = e.target.checked;
+
+    if (checked) {
+      const scheduleCourse = await fetchCourse(
+        course.subject,
+        String(course.classId)
+      );
+      if (scheduleCourse) {
+        this.setState({
+          selectedCourses: [...this.state.selectedCourses, scheduleCourse],
+        });
+      }
+    } else {
+      const courses = this.state.selectedCourses;
+      courses.filter(
+        c =>
+          c.subject !== course.subject && c.classId !== String(course.classId)
+      );
+      this.setState({
+        selectedCourses: courses,
+      });
+    }
+  }
+
+  renderCourse(
+    course: IRequiredCourse,
+    noMargin: boolean = false,
+    checkbox: boolean = true
+  ) {
+    return (
+      <CourseWrapper key={course.subject + course.classId + course.type}>
+        {checkbox && (
+          <Checkbox
+            value="primary"
+            color="primary"
+            onChange={e => this.handleChecked(e, course)}
+          />
+        )}
+        {noMargin ? (
+          <CourseTextNoMargin>
+            {course.subject + course.classId}
+          </CourseTextNoMargin>
+        ) : (
+          <CourseText>{course.subject + course.classId}</CourseText>
+        )}
+      </CourseWrapper>
+    );
+  }
+
+  handleRange(req: ICourseRange) {
+    return (
+      <div>
+        <ANDORText style={{ marginBottom: 8 }}>
+          Complete {req.creditsRequired} credits from the following courses that
+          are not already required:
+        </ANDORText>
+        {req.ranges.map((r: ISubjectRange, index: number) => {
+          return (
+            <CourseText key={r.subject + r.idRangeStart + " - " + r.idRangeEnd}>
+              {r.subject + r.idRangeStart + " through " + r.idRangeEnd}
+            </CourseText>
+          );
+        })}
+      </div>
+    );
+  }
+
+  renderRequirement(req: Requirement, index: number) {
+    if (req.type === "COURSE") {
+      return this.renderCourse(req as IRequiredCourse);
+    }
+
+    if (req.type === "RANGE") {
+      return this.handleRange(req as ICourseRange);
+    }
+
+    if (
+      req.type === "AND" &&
+      req.courses.length === 2 &&
+      req.courses.filter(c => c.type === "COURSE").length === 2
+    ) {
+      return (
+        <CourseAndLabWrapper key={index}>
+          <Checkbox
+            value="primary"
+            color="primary"
+            onChange={e => {
+              this.handleChecked(e, req.courses[0] as IRequiredCourse);
+              this.handleChecked(e, req.courses[1] as IRequiredCourse);
+            }}
+          />
+          {this.renderCourse(req.courses[0] as IRequiredCourse, true, false)}
+          <CourseText> and </CourseText>
+          {this.renderCourse(req.courses[1] as IRequiredCourse, true, false)}
+        </CourseAndLabWrapper>
+      );
+    }
+
+    return (
+      <div key={index.toString()}>
+        {req.courses
+          .filter(c => c.type === "COURSE")
+          .map(c => this.renderCourse(c as IRequiredCourse))}
+        {req.courses
+          .filter(c => c.type === "AND")
+          .map((c: Requirement, index: number) =>
+            this.renderRequirement(c, index)
+          )}
+        {req.courses
+          .filter(c => c.type === "OR")
+          .map((c: Requirement, index: number) =>
+            this.renderRequirement(c, index)
+          )}
+      </div>
+    );
+  }
+
+  parseRequirements(reqs: Requirement[]) {
+    return reqs.map((r: Requirement, index: number) => (
+      <div key={index}>{this.renderRequirement(r, index)}</div>
+    ));
+  }
+
+  renderSection(requirementGroup: string) {
+    const reqs = this.props.major.requirementGroupMap[requirementGroup];
+    if (!reqs) {
+      return <div />;
+    }
+
+    if (reqs.type === "RANGE") {
+      return <div />;
+    }
+
+    return (
+      <div>
+        <TitleText>{requirementGroup}</TitleText>
+        {this.parseRequirements(reqs.requirements)}
+      </div>
+    );
+  }
+
   render() {
     return (
-      <GenericQuestionTemplate question="Which classes have you taken?">
-        <div></div>
-      </GenericQuestionTemplate>
+      <Wrapper>
+        <Box>
+          <Title>Course List</Title>
+          <Question>Which classes have you taken?</Question>
+          {this.props.major.requirementGroups.map(r => this.renderSection(r))}
+          <Link
+            to={"/home"}
+            onClick={this.onSubmit.bind(this)}
+            style={{ textDecoration: "none" }}
+          >
+            <NextButton />
+          </Link>
+          <BottomSpace />
+        </Box>
+      </Wrapper>
     );
   }
 }
 
 const mapStateToProps = (state: AppState) => ({
-  major: getMajorFromState(state),
+  major: getMajorFromState(state)!,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -42,7 +275,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(addCompletedCourses(completedCourses)),
 });
 
-export const CompletedCoursesScreen = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CompletedCoursesComponent);
+export const CompletedCoursesScreen = withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(CompletedCoursesComponent)
+);

--- a/frontend/src/Onboarding/CompletedCoursesScreen.tsx
+++ b/frontend/src/Onboarding/CompletedCoursesScreen.tsx
@@ -11,7 +11,7 @@ import {
   ISubjectRange,
 } from "../models/types";
 import { getMajorFromState } from "../state";
-import { addCompletedCourses } from "../state/actions/scheduleActions";
+import { setCompletedCourses } from "../state/actions/scheduleActions";
 import styled from "styled-components";
 import { Checkbox } from "@material-ui/core";
 import { fetchCourse } from "../api";
@@ -230,15 +230,15 @@ class CompletedCoursesComponent extends Component<Props, State> {
   renderSection(requirementGroup: string) {
     const reqs = this.props.major.requirementGroupMap[requirementGroup];
     if (!reqs) {
-      return <div />;
+      return <div key={requirementGroup} />;
     }
 
     if (reqs.type === "RANGE") {
-      return <div />;
+      return <div key={requirementGroup} />;
     }
 
     return (
-      <div>
+      <div key={requirementGroup}>
         <TitleText>{requirementGroup}</TitleText>
         {this.parseRequirements(reqs.requirements)}
       </div>
@@ -272,7 +272,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setCompletedCourses: (completedCourses: ScheduleCourse[]) =>
-    dispatch(addCompletedCourses(completedCourses)),
+    dispatch(setCompletedCourses(completedCourses)),
 });
 
 export const CompletedCoursesScreen = withRouter(

--- a/frontend/src/Onboarding/CompletedCoursesScreen.tsx
+++ b/frontend/src/Onboarding/CompletedCoursesScreen.tsx
@@ -22,11 +22,11 @@ const Wrapper = styled.div`
   display: flex;
   flex: 1;
   justify-content: center;
-  height: 100vh;
 `;
 
 const Box = styled.div`
   margin-top: 20vh;
+  margin-bottom: 20vh;
   border: 1px solid black;
   padding: 18px;
   width: 500px;
@@ -73,10 +73,6 @@ const CourseAndLabWrapper = styled.div`
 const ANDORText = styled.p`
   font-size: 11px;
   margin: 4px;
-`;
-
-const BottomSpace = styled.div`
-  margin-bottom: 20vh;
 `;
 
 interface CompletedCoursesScreenProps {
@@ -259,7 +255,6 @@ class CompletedCoursesComponent extends Component<Props, State> {
           >
             <NextButton />
           </Link>
-          <BottomSpace />
         </Box>
       </Wrapper>
     );

--- a/frontend/src/Onboarding/MajorScreen.tsx
+++ b/frontend/src/Onboarding/MajorScreen.tsx
@@ -113,9 +113,9 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
           {!!this.state.major && this.renderPlansDropDown()}
         </DropDownWrapper>
         <Link
-          to={{
-            pathname: "/home", // change to "/minors" to go to the minors screen
-          }}
+          to={
+            !!this.state.major ? "/completedCourses" : "/home" // change to "/minors" to go to the minors screen
+          }
           onClick={this.onSubmit.bind(this)}
           style={{ textDecoration: "none" }}
         >
@@ -132,7 +132,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   setPlan: (plan: Schedule) => dispatch(setScheduleAction(plan)),
 });
 
-export const MajorScreen = connect(
-  null,
-  mapDispatchToProps
-)(withRouter(MajorComponent));
+export const MajorScreen = withRouter(
+  connect(
+    null,
+    mapDispatchToProps
+  )(MajorComponent)
+);

--- a/frontend/src/Onboarding/MajorScreen.tsx
+++ b/frontend/src/Onboarding/MajorScreen.tsx
@@ -6,6 +6,7 @@ import { NextButton } from "../components/common/NextButton";
 import { Autocomplete } from "@material-ui/lab";
 import { Major, Schedule } from "../models/types";
 import styled from "styled-components";
+import { plans } from "../plans";
 import { planToString } from "../utils";
 import { connect } from "react-redux";
 import { setMajorAction } from "../state/actions/userActions";
@@ -126,6 +127,26 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
     );
   }
 
+  renderPlansDropDown() {
+    return (
+      <Autocomplete
+        style={{ width: 300 }}
+        disableListWrap
+        options={plans[this.state.major!.name].map(p => planToString(p))}
+        renderInput={params => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label="Select A Plan"
+            fullWidth
+          />
+        )}
+        value={this.state.planStr || ""}
+        onChange={this.onChoosePlan.bind(this)}
+      />
+    );
+  }
+
   render() {
     const { isFetchingMajors, isFetchingPlans } = this.props;
     if (isFetchingMajors || isFetchingPlans) {
@@ -162,6 +183,7 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
     }
   }
 }
+
 
 /**
  * Callback to be passed into connect, to make properties of the AppState available as this components props.

--- a/frontend/src/components/DropDownModal.tsx
+++ b/frontend/src/components/DropDownModal.tsx
@@ -1,8 +1,24 @@
 import * as React from "react";
 import styled from "styled-components";
-import { DNDSchedule } from "../models/types";
+import { DNDScheduleCourse } from "../models/types";
 import ExpandMoreOutlinedIcon from "@material-ui/icons/ExpandMoreOutlined";
 import ExpandLessOutlinedIcon from "@material-ui/icons/ExpandLessOutlined";
+import { connect } from "react-redux";
+import { AppState } from "../state/reducers/state";
+import { getCompletedCoursesFromState } from "../state";
+import {
+  sumCreditsFromList,
+  getStandingFromCompletedCourses,
+  COMPLETED_COURSES_AREA_DROPPABLE_ID,
+  getNumberOfCompletedCourses,
+} from "../utils";
+import { Droppable } from "react-beautiful-dnd";
+import { EmptyBlock } from ".";
+import { ClassBlock } from "./ClassBlocks";
+import { Dispatch } from "redux";
+import { removeCompletedCoursesAction } from "../state/actions/scheduleActions";
+import { SEMESTER_MIN_HEIGHT, CLASS_BLOCK_WIDTH } from "../constants";
+import { ICompletedCoursesMap } from "../state/reducers/scheduleReducer";
 
 const Wrapper = styled.div`
   display: flex;
@@ -20,19 +36,30 @@ const TopInfo = styled.div`
 
 const BottomInfo = styled.div`
   display: flex;
-  height: 200px;
+  flex-direction: row;
+  min-height: ${SEMESTER_MIN_HEIGHT}px;
   background-color: #fafafa;
+  border: 2px solid lightgrey;
 `;
 
-export interface IDropDownModalProps {
-  schedule: DNDSchedule;
+const ListWrapper = styled.div<any>`
+  display: flex;
+  min-height: ${SEMESTER_MIN_HEIGHT}px;
+  flex-direction: column;
+  width: ${CLASS_BLOCK_WIDTH + 4}px;
+  height: 100%;
+`;
+
+interface IDropDownModalProps {
+  completedCourses: ICompletedCoursesMap;
+  onDeleteClass: (course: DNDScheduleCourse) => void;
 }
 
-export interface IDropDownModalState {
+interface IDropDownModalState {
   expanded: boolean;
 }
 
-export class DropDownModal extends React.Component<
+class DropDownModalComponent extends React.Component<
   IDropDownModalProps,
   IDropDownModalState
 > {
@@ -47,21 +74,67 @@ export class DropDownModal extends React.Component<
     this.setState({ expanded: !this.state.expanded });
   }
 
+  renderListOfClasses(courses: DNDScheduleCourse[]) {
+    return courses.map((scheduleCourse, index) => {
+      if (!!scheduleCourse) {
+        return (
+          <ClassBlock
+            key={index}
+            class={scheduleCourse}
+            index={index}
+            onDelete={() => this.props.onDeleteClass(scheduleCourse)}
+          />
+        );
+      }
+      return <EmptyBlock key={index} />;
+    });
+  }
+
+  renderSections() {
+    return [0, 1, 2, 3].map(v => (
+      <Droppable droppableId={COMPLETED_COURSES_AREA_DROPPABLE_ID + "-" + v}>
+        {provided => (
+          <ListWrapper {...provided.droppableProps} ref={provided.innerRef}>
+            {this.renderListOfClasses(this.props.completedCourses[v])}
+            {provided.placeholder}
+          </ListWrapper>
+        )}
+      </Droppable>
+    ));
+  }
+
   render() {
+    const { completedCourses } = this.props;
     return (
       <Wrapper>
         <TopInfo onClick={this.handleClick.bind(this)}>
-          <p>4 courses</p>
-          <p>16 credits</p>
-          <p>Freshman Standing</p>
+          <p>{getNumberOfCompletedCourses(completedCourses)} courses</p>
+          <p>{sumCreditsFromList(completedCourses)} credits</p>
+          <p>{getStandingFromCompletedCourses(completedCourses)} Standing</p>
           {this.state.expanded ? (
             <ExpandLessOutlinedIcon />
           ) : (
             <ExpandMoreOutlinedIcon />
           )}
         </TopInfo>
-        {this.state.expanded && <BottomInfo></BottomInfo>}
+        {this.state.expanded && (
+          <BottomInfo>{this.renderSections()}</BottomInfo>
+        )}
       </Wrapper>
     );
   }
 }
+
+const mapStateToProps = (state: AppState) => ({
+  completedCourses: getCompletedCoursesFromState(state),
+});
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onDeleteClass: (course: DNDScheduleCourse) =>
+    dispatch(removeCompletedCoursesAction(course)),
+});
+
+export const DropDownModal = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(DropDownModalComponent);

--- a/frontend/src/home/Home.tsx
+++ b/frontend/src/home/Home.tsx
@@ -52,7 +52,7 @@ import {
   setCompletedCoursesFromMap,
   setCoopCycle,
 } from "../state/actions/scheduleActions";
-import { setPlanStrAction, setMajorAction } from "../state/actions/userActions";
+import { setMajorAction } from "../state/actions/userActions";
 import { ICompletedCoursesMap } from "../state/reducers/scheduleReducer";
 import { getMajors, getPlans } from "../state";
 

--- a/frontend/src/state/actions/scheduleActions.ts
+++ b/frontend/src/state/actions/scheduleActions.ts
@@ -52,3 +52,8 @@ export const setDNDScheduleAction = createAction(
   "schedule/SET_DND_SCHEDULE",
   (schedule: DNDSchedule) => ({ schedule })
 )();
+
+export const addCompletedCourses = createAction(
+  "schedule/ADD_COMPLETED_COURSES",
+  (completedCourses: ScheduleCourse[]) => ({ completedCourses })
+)();

--- a/frontend/src/state/actions/scheduleActions.ts
+++ b/frontend/src/state/actions/scheduleActions.ts
@@ -8,6 +8,7 @@ import {
   Schedule,
   DNDSchedule,
 } from "../../models/types";
+import { ICompletedCoursesMap } from "../reducers/scheduleReducer";
 
 export const addClassesAction = createAction(
   "schedule/ADD_CLASSES",
@@ -56,4 +57,19 @@ export const setDNDScheduleAction = createAction(
 export const addCompletedCourses = createAction(
   "schedule/ADD_COMPLETED_COURSES",
   (completedCourses: ScheduleCourse[]) => ({ completedCourses })
+)();
+
+export const setCompletedCourses = createAction(
+  "schedule/SET_COMPLETED_COURSES",
+  (completedCourses: ScheduleCourse[]) => ({ completedCourses })
+)();
+
+export const setCompletedCoursesFromMap = createAction(
+  "schedule/SET_COMPLETED_COURSES_FROM_MAP",
+  (completedCourses: ICompletedCoursesMap) => ({ completedCourses })
+)();
+
+export const removeCompletedCoursesAction = createAction(
+  "schedule/REMOVE_COMPLETED_COURSES",
+  (completedCourse: DNDScheduleCourse) => ({ completedCourse })
 )();

--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -6,6 +6,7 @@ import {
   IWarning,
   DNDScheduleTerm,
 } from "../models/types";
+import { ICompletedCoursesMap } from "./reducers/scheduleReducer";
 
 export const getFullNameFromState = (state: AppState): string =>
   state.user.fullName;
@@ -27,3 +28,7 @@ export const getCourseWarningsFromState = (
   semester: DNDScheduleTerm
 ): CourseWarning[] =>
   state.schedule.courseWarnings.filter(w => w.termId === semester.termId);
+
+export const getCompletedCoursesFromState = (
+  state: AppState
+): ICompletedCoursesMap => state.schedule.completedCourses;

--- a/frontend/src/state/reducers/scheduleReducer.ts
+++ b/frontend/src/state/reducers/scheduleReducer.ts
@@ -1,4 +1,9 @@
-import { DNDSchedule, IWarning, CourseWarning } from "../../models/types";
+import {
+  DNDSchedule,
+  IWarning,
+  CourseWarning,
+  DNDScheduleCourse,
+} from "../../models/types";
 import { mockData } from "../../data/mockData";
 import produce from "immer";
 import { getType } from "typesafe-actions";
@@ -10,6 +15,7 @@ import {
   updateSemesterAction,
   setScheduleAction,
   setDNDScheduleAction,
+  addCompletedCourses,
 } from "../actions/scheduleActions";
 import {
   convertTermIdToSeason,
@@ -25,6 +31,7 @@ export interface ScheduleState {
   schedule: DNDSchedule;
   warnings: IWarning[];
   courseWarnings: CourseWarning[];
+  completedCourses: DNDScheduleCourse[];
 }
 
 const initialState: ScheduleState = {
@@ -34,6 +41,7 @@ const initialState: ScheduleState = {
   schedule: mockData,
   warnings: [],
   courseWarnings: [],
+  completedCourses: [],
 };
 
 export const scheduleReducer = (
@@ -129,6 +137,17 @@ export const scheduleReducer = (
 
         draft.warnings = container.normalWarnings;
         draft.courseWarnings = container.courseWarnings;
+
+        return draft;
+      }
+      case getType(addCompletedCourses): {
+        const [dndCourses, newCounter] = convertToDNDCourses(
+          action.payload.completedCourses,
+          draft.currentClassCounter
+        );
+
+        draft.currentClassCounter = newCounter;
+        draft.completedCourses.push(...dndCourses);
 
         return draft;
       }

--- a/frontend/src/utils/completed-courses-helpers.ts
+++ b/frontend/src/utils/completed-courses-helpers.ts
@@ -1,0 +1,42 @@
+import { ICompletedCoursesMap } from "../state/reducers/scheduleReducer";
+
+export function sumCreditsFromList(courses: ICompletedCoursesMap): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    for (const course of courses[i]) {
+      sum += course.numCreditsMax;
+    }
+  }
+  return sum;
+}
+
+export function getStandingFromCompletedCourses(
+  courses: ICompletedCoursesMap
+): string {
+  const credits = sumCreditsFromList(courses);
+
+  if (credits < 32) {
+    return "Freshman";
+  }
+  if (credits < 64) {
+    return "Sophomore";
+  }
+  if (credits < 96) {
+    return "Junior";
+  }
+  return "Senior";
+}
+
+export function getNumberOfCompletedCourses(
+  courses: ICompletedCoursesMap
+): number {
+  let sum = 0;
+  for (let i = 0; i < 4; i++) {
+    sum += courses[i].length;
+  }
+  return sum;
+}
+
+export function getIndexFromCompletedCoursesDNDID(dndId: string): number {
+  return Number(dndId[dndId.length - 1]);
+}

--- a/frontend/src/utils/completed-courses-helpers.ts
+++ b/frontend/src/utils/completed-courses-helpers.ts
@@ -1,6 +1,10 @@
 import { ICompletedCoursesMap } from "../state/reducers/scheduleReducer";
 
 export function sumCreditsFromList(courses: ICompletedCoursesMap): number {
+  if (!courses) {
+    return 0;
+  }
+  
   let sum = 0;
   for (let i = 0; i < 4; i++) {
     for (const course of courses[i]) {
@@ -30,6 +34,10 @@ export function getStandingFromCompletedCourses(
 export function getNumberOfCompletedCourses(
   courses: ICompletedCoursesMap
 ): number {
+  if (!courses) {
+    return 0;
+  }
+
   let sum = 0;
   for (let i = 0; i < 4; i++) {
     sum += courses[i].length;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./dnd-helpers";
 export * from "./generate-warnings";
 export * from "./schedule-helpers";
+export * from "./completed-courses-helpers";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,9 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "suppressImplicitAnyIndexErrors": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "jsx": "react",
     "outDir": "./build",
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true
   },
   "include": ["src", "backend/src/**/*", "frontend/**/*"]
 }


### PR DESCRIPTION
This PR adds the completed courses onboarding screen (right after the majors onboarding question).

Also it fills the little grey box with your completed courses information. And it puts the courses themselves in there too and you can drag them wherever you want (to your schedule or just around the box).

Note: Due to some state changes, you might get a error or a white screen when you load it in ZEIT. To fix this, go to the Google Chrome inspect thing, go to the Application tab, go to Clear Storage, and click on Clear Site Data. 