### PR TITLE
Change plan of study to truly just "coop cycle"

### DIFF
--- a/frontend/src/Onboarding/MajorScreen.tsx
+++ b/frontend/src/Onboarding/MajorScreen.tsx
@@ -10,9 +10,9 @@ import styled from "styled-components";
 import { plans } from "../plans";
 import { planToString } from "../utils";
 import { connect } from "react-redux";
-import { setMajorAction, setPlanStrAction } from "../state/actions/userActions";
+import { setMajorAction } from "../state/actions/userActions";
 import { Dispatch } from "redux";
-import { setScheduleAction } from "../state/actions/scheduleActions";
+import { setCoopCycle } from "../state/actions/scheduleActions";
 
 const DropDownWrapper = styled.div`
   display: flex;
@@ -21,8 +21,7 @@ const DropDownWrapper = styled.div`
 
 interface MajorScreenProps {
   setMajor: (major?: Major) => void;
-  setPlanStr: (planStr?: string) => void;
-  setPlan: (plan: Schedule) => void;
+  setCoopCycle: (plan: Schedule) => void;
 }
 
 interface MajorScreenState {
@@ -54,14 +53,13 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
 
   onSubmit() {
     this.props.setMajor(this.state.major);
-    this.props.setPlanStr(this.state.planStr);
 
     if (this.state.planStr) {
       const plan = plans[this.state.major!.name].find(
         (p: Schedule) => planToString(p) === this.state.planStr
       );
 
-      this.props.setPlan(plan!);
+      this.props.setCoopCycle(plan!);
     }
   }
 
@@ -85,7 +83,7 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
     );
   }
 
-  renderPlansDropDown() {
+  renderCoopCycleDropDown() {
     return (
       <Autocomplete
         style={{ width: 300 }}
@@ -95,7 +93,7 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
           <TextField
             {...params}
             variant="outlined"
-            label="Select A Plan"
+            label="Select A Co-op Cycle"
             fullWidth
           />
         )}
@@ -110,7 +108,7 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
       <GenericQuestionTemplate question="What is your major?">
         <DropDownWrapper>
           {this.renderMajorDropDown()}
-          {!!this.state.major && this.renderPlansDropDown()}
+          {!!this.state.major && this.renderCoopCycleDropDown()}
         </DropDownWrapper>
         <Link
           to={{
@@ -128,8 +126,7 @@ class MajorComponent extends React.Component<Props, MajorScreenState> {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setMajor: (major?: Major) => dispatch(setMajorAction(major)),
-  setPlanStr: (planStr?: string) => dispatch(setPlanStrAction(planStr)),
-  setPlan: (plan: Schedule) => dispatch(setScheduleAction(plan)),
+  setCoopCycle: (plan: Schedule) => dispatch(setCoopCycle(plan)),
 });
 
 export const MajorScreen = connect(

--- a/frontend/src/components/SemesterBlock.tsx
+++ b/frontend/src/components/SemesterBlock.tsx
@@ -180,8 +180,8 @@ class SemesterBlockComponent extends React.Component<
   renderTooltip() {
     return (
       <div style={{ display: "flex", flexDirection: "column" }}>
-        {this.props.warnings.map(w => {
-          return <span>{w.message}</span>;
+        {this.props.warnings.map((w, index) => {
+          return <span key={index}>{w.message}</span>;
         })}
       </div>
     );

--- a/frontend/src/state/actions/scheduleActions.ts
+++ b/frontend/src/state/actions/scheduleActions.ts
@@ -53,6 +53,11 @@ export const setScheduleAction = createAction(
   (schedule: Schedule) => ({ schedule })
 )();
 
+export const setCoopCycle = createAction(
+  "schedule/SET_COOP_CYCLE",
+  (schedule?: Schedule) => ({ schedule })
+)();
+
 export const setDNDScheduleAction = createAction(
   "schedule/SET_DND_SCHEDULE",
   (schedule: DNDSchedule) => ({ schedule })

--- a/frontend/src/state/actions/userActions.ts
+++ b/frontend/src/state/actions/userActions.ts
@@ -22,13 +22,6 @@ export const setGraduationYearAction = createAction(
   })
 )();
 
-export const setPlanStrAction = createAction(
-  "user/SET_PLAN_STR",
-  (planStr?: string) => ({
-    planStr,
-  })
-)();
-
 export const setMajorAction = createAction(
   "user/SET_MAJOR",
   (major?: Major) => ({

--- a/frontend/src/state/reducers/userReducer.ts
+++ b/frontend/src/state/reducers/userReducer.ts
@@ -1,14 +1,15 @@
 import { Major } from "../../models/types";
 import produce from "immer";
 import { getType } from "typesafe-actions";
-import { UserAction } from "../actions";
+import { UserAction, ScheduleAction } from "../actions";
 import {
   setMajorAction,
-  setPlanStrAction,
   setFullNameAction,
   setAcademicYearAction,
   setGraduationYearAction,
 } from "../actions/userActions";
+import { setCoopCycle } from "../actions/scheduleActions";
+import { planToString } from "../../utils";
 
 export interface UserState {
   fullName: string;
@@ -28,12 +29,16 @@ const initialState: UserState = {
 
 export const userReducer = (
   state: UserState = initialState,
-  action: UserAction
+  action: UserAction | ScheduleAction
 ) => {
   return produce(state, draft => {
     switch (action.type) {
-      case getType(setPlanStrAction): {
-        draft.planStr = action.payload.planStr;
+      case getType(setCoopCycle): {
+        if (action.payload.schedule) {
+          draft.planStr = planToString(action.payload.schedule);
+        } else {
+          draft.planStr = undefined;
+        }
         return draft;
       }
       case getType(setMajorAction): {

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -75,7 +75,7 @@ export const convertToDNDSchedule = (
   schedule: Schedule,
   counter: number
 ): [DNDSchedule, number] => {
-  const newSchedule = schedule as DNDSchedule;
+  const newSchedule = JSON.parse(JSON.stringify(schedule)) as DNDSchedule;
   for (const year of Object.keys(schedule.yearMap)) {
     var result = convertToDNDCourses(
       newSchedule.yearMap[year as any].fall.classes as ScheduleCourse[],
@@ -125,4 +125,19 @@ export const convertToDNDCourses = (
 
 export function isCoopOrVacation(currSemester: DNDScheduleTerm): boolean {
   return currSemester.status.includes("HOVER");
+}
+
+export function scheduleHasClasses(schedule: Schedule): boolean {
+  for (const y of schedule.years) {
+    const year = schedule.yearMap[y];
+    if (
+      year.fall.classes.length !== 0 ||
+      year.spring.classes.length !== 0 ||
+      year.summer1.classes.length !== 0 ||
+      year.summer2.classes.length !== 0
+    ) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
This PR modifies the plan of study question to only modify the schedule's coop cycle. This way users aren't flooded with a full schedule once they choose their coop cycle. 

Also there is a button for adding all of the courses from the plan they chose. With a clear schedule option too!