### PR TITLE
Add job to CI to ensure validity of docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  run-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,3 +19,22 @@ jobs:
         run: |
           yarn install
           yarn test
+  build-frontend-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image for frontend
+        run: |
+          docker build -t frontend -f frontend/Dockerfile .
+  build-api-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build Docker image for api
+        run: |
+          cd api
+          docker build -t api .


### PR DESCRIPTION
Checks validity of docker builds as part of CI so we don’t inadvertently merge in PRs that break the deploy to AWS  on merge to master