### PR TITLE
Add Plan Popper Errors

### DIFF
--- a/frontend/src/home/AddPlanPopper.tsx
+++ b/frontend/src/home/AddPlanPopper.tsx
@@ -309,7 +309,7 @@ function AddPlanPopperComponent(props: Props) {
         <Select
           labelId="demo-simple-select-outlined-label"
           id="demo-simple-select-outlined"
-          labelWidth={115}
+          labelWidth={160}
           onChange={setSelect}
           displayEmpty
           value={selectedPlanOption}

--- a/frontend/src/home/AddPlanPopper.tsx
+++ b/frontend/src/home/AddPlanPopper.tsx
@@ -356,7 +356,7 @@ function AddPlanPopperComponent(props: Props) {
           <TextField
             {...params}
             variant="outlined"
-            label="Select A Co-op Cycle"
+            label="Select One of Your Plans"
             fullWidth
           />
         )}

--- a/frontend/src/home/AddPlanPopper.tsx
+++ b/frontend/src/home/AddPlanPopper.tsx
@@ -214,7 +214,7 @@ function AddPlanPopperComponent(props: Props) {
         name: planName,
         link_sharing_enabled: false,
         schedule: selectedDNDSchedule.current!,
-        major: selectedMajor!.name || "",
+        major: selectedMajor ? selectedMajor.name : "",
         planString: selectedCoopCycle,
         course_counter: counter.current,
         warnings: [],

--- a/frontend/src/home/AddPlanPopper.tsx
+++ b/frontend/src/home/AddPlanPopper.tsx
@@ -47,7 +47,7 @@ const ERROR_MESSAGE =
 
 const PLAN_OPTIONS = {
   NEW_PLAN: "New Plan",
-  EXISITNG_PLAN: "Exisitng Plan",
+  EXISTING_PLAN: "Existing Plan",
   EXAMPLE_PLAN: "Example Major Plan",
   UPLOAD_PLAN: "Upload Plan Of Study",
 };
@@ -334,10 +334,10 @@ function AddPlanPopperComponent(props: Props) {
             </MenuItem>
           )}
           <MenuItem
-            value={PLAN_OPTIONS.EXISITNG_PLAN}
+            value={PLAN_OPTIONS.EXISTING_PLAN}
             title={COPY_PLAN_TOOLTIP}
           >
-            {PLAN_OPTIONS.EXISITNG_PLAN}
+            {PLAN_OPTIONS.EXISTING_PLAN}
           </MenuItem>
           <MenuItem value={PLAN_OPTIONS.UPLOAD_PLAN} title={EXCEL_TOOLTIP}>
             {PLAN_OPTIONS.UPLOAD_PLAN}
@@ -405,7 +405,7 @@ function AddPlanPopperComponent(props: Props) {
             {renderSelectOptions()}
             {selectedPlanOption == PLAN_OPTIONS.UPLOAD_PLAN ? (
               <ExcelUpload setSchedule={setSchedule} />
-            ) : selectedPlanOption === PLAN_OPTIONS.EXISITNG_PLAN ? (
+            ) : selectedPlanOption === PLAN_OPTIONS.EXISTING_PLAN ? (
               renderSelectPlan()
             ) : null}
             {error && (


### PR DESCRIPTION
Handled the following tickets:
https://trello.com/c/N0EP4QeB/180-create-plan-based-on-dropdown-border-overlaps-with-title-within-create-plan-popper
https://trello.com/c/x1p7LIAR/173-typo-in-create-plan-popper-when-creating-new-plan-from-existing-plan
https://trello.com/c/r8XKXASe/177-create-plan-popper-shows-an-error-when-submitting-without-setting-a-major
https://trello.com/c/yC39m66H/179-create-plan-popper-says-select-a-co-op-cycle-within-dropdown-for-selecting-an-existing-plan