### PR TITLE
Fix Deep Copying Error caused by Closed years

### DIFF
--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -228,7 +228,7 @@ export const isUserLoggedIn = (state: AppState): boolean => {
 };
 
 export const getClosedYearsFromState = (state: AppState): Set<number> => {
-  return state.schedule.present.closedYears;
+  return new Set(state.schedule.present.closedYears);
 };
 
 /**

--- a/frontend/src/state/reducers/scheduleReducer.ts
+++ b/frontend/src/state/reducers/scheduleReducer.ts
@@ -59,7 +59,7 @@ export interface ScheduleStateSlice {
   transferCourses: ScheduleCourse[];
   major: string;
   coopCycle: string;
-  closedYears: Set<number>; // list of indexes for which years are not expanded in the UI
+  closedYears: number[]; // list of indexes for which years are not expanded in the UI
 }
 
 const initialState: ScheduleState = {
@@ -75,7 +75,7 @@ const initialState: ScheduleState = {
     transferCourses: [],
     major: "",
     coopCycle: "",
-    closedYears: new Set(),
+    closedYears: [],
   },
 };
 
@@ -323,20 +323,20 @@ export const scheduleReducer = (
         return draft;
       }
       case getType(setClosedYearsToYearsInThePast): {
-        draft.present.closedYears = new Set();
+        draft.present.closedYears = [];
         for (var i = 0; i < draft.present.schedule.years.length; i++) {
           if (isYearInPast(i, action.payload.academicYear)) {
-            draft.present.closedYears.add(i);
+            draft.present.closedYears.push(i);
           }
         }
         return draft;
       }
       case getType(toggleYearExpanded): {
         const idx = action.payload.index;
-        if (draft.present.closedYears.has(idx)) {
-          draft.present.closedYears.delete(idx);
+        if (draft.present.closedYears.includes(idx)) {
+          draft.present.closedYears.filter(year => year !== idx);
         } else {
-          draft.present.closedYears.add(idx);
+          draft.present.closedYears.push(idx);
         }
         return draft;
       }


### PR DESCRIPTION
Switch redux props for closed years to be an array instead of a set to avoid deep copying errors