### PR TITLE
Set up Redux Store for Advisors

### DIFF
--- a/frontend/src/state/actions/advisorActions.ts
+++ b/frontend/src/state/actions/advisorActions.ts
@@ -1,0 +1,32 @@
+import { createAction } from "typesafe-actions";
+import { Student } from "../reducers/advisorReducer";
+
+export const setEmail = createAction("advisor/SET_EMAIL", (email: string) => ({
+  email,
+}))();
+
+export const setName = createAction("advisor/SET_NAME", (name: string) => ({
+  name,
+}))();
+
+export const setToken = createAction("advisor/SET_TOKEN", (token: string) => ({
+  token,
+}))();
+
+export const setUserId = createAction(
+  "advisor/SET_USER_ID",
+  (userId: number) => ({
+    userId,
+  })
+)();
+
+export const setImage = createAction("advisor/SET_IMAGE", (image: string) => ({
+  image,
+}))();
+
+export const setStudents = createAction(
+  "advisor/SET_STUDENTS",
+  (students: Array<Student>) => ({
+    students,
+  })
+)();

--- a/frontend/src/state/actions/index.ts
+++ b/frontend/src/state/actions/index.ts
@@ -3,6 +3,7 @@ import * as majorsActions from "./majorsActions";
 import * as userActions from "./userActions";
 import * as plansActions from "./plansActions";
 import * as schedulesActions from "./schedulesActions";
+import * as advisorActions from "./advisorActions";
 import { ActionType } from "typesafe-actions";
 
 export type ScheduleAction = ActionType<typeof scheduleActions>;
@@ -10,3 +11,4 @@ export type UserAction = ActionType<typeof userActions>;
 export type MajorsApiAction = ActionType<typeof majorsActions>;
 export type PlansApiAction = ActionType<typeof plansActions>;
 export type SchedulesAction = ActionType<typeof schedulesActions>;
+export type AdvisorAction = ActionType<typeof advisorActions>;

--- a/frontend/src/state/reducers/advisorReducer.ts
+++ b/frontend/src/state/reducers/advisorReducer.ts
@@ -3,4 +3,5 @@ export interface AdvisorState {
   readonly token: string;
   readonly userId: number;
   readonly email: string;
+  readonly image: string;
 }

--- a/frontend/src/state/reducers/advisorReducer.ts
+++ b/frontend/src/state/reducers/advisorReducer.ts
@@ -1,0 +1,6 @@
+export interface AdvisorState {
+  readonly name: string;
+  readonly token: string;
+  readonly userId: number;
+  readonly email: string;
+}

--- a/frontend/src/state/reducers/advisorReducer.ts
+++ b/frontend/src/state/reducers/advisorReducer.ts
@@ -1,7 +1,73 @@
-export interface AdvisorState {
-  readonly name: string;
-  readonly token: string;
-  readonly userId: number;
+import produce from "immer";
+import { getType } from "typesafe-actions";
+import { AdvisorAction } from "../actions";
+import {
+  setEmail,
+  setImage,
+  setName,
+  setStudents,
+  setToken,
+  setUserId,
+} from "../actions/advisorActions";
+
+export interface Student {
   readonly email: string;
-  readonly image: string;
+  readonly name: string;
 }
+
+export interface AdvisorState {
+  readonly email: string;
+  readonly name: string;
+  readonly token?: string;
+  readonly userId?: number;
+  readonly image: string;
+  readonly students: Array<Student>;
+}
+
+const initialState: AdvisorState = {
+  email: "",
+  name: "",
+  token: undefined,
+  userId: undefined,
+  image: "",
+  students: [],
+};
+
+export const advisorReducer = (
+  state: AdvisorState = initialState,
+  action: AdvisorAction
+) => {
+  return produce(state, draft => {
+    switch (action.type) {
+      case getType(setEmail): {
+        draft.email = action.payload.email;
+        return draft;
+      }
+
+      case getType(setName): {
+        draft.name = action.payload.name;
+        return draft;
+      }
+
+      case getType(setToken): {
+        draft.token = action.payload.token;
+        return draft;
+      }
+
+      case getType(setUserId): {
+        draft.userId = action.payload.userId;
+        return draft;
+      }
+
+      case getType(setImage): {
+        draft.image = action.payload.image;
+        return draft;
+      }
+
+      case getType(setStudents): {
+        draft.students = action.payload.students;
+        return draft;
+      }
+    }
+  });
+};

--- a/frontend/src/state/reducers/state.ts
+++ b/frontend/src/state/reducers/state.ts
@@ -8,6 +8,7 @@ import {
   majorsReducer,
   plansReducer,
 } from "./apiReducer";
+import { advisorReducer, AdvisorState } from "./advisorReducer";
 
 export interface AppState {
   schedule: ScheduleState;
@@ -15,6 +16,7 @@ export interface AppState {
   majorState: MajorApiState;
   plansState: PlansApiState;
   schedules: SchedulesState;
+  advisorState: AdvisorState;
 }
 
 export const rootReducer = combineReducers({
@@ -23,4 +25,5 @@ export const rootReducer = combineReducers({
   majorState: majorsReducer,
   plansState: plansReducer,
   schedules: schedulesReducer,
+  advisorState: advisorReducer,
 });


### PR DESCRIPTION
https://trello.com/c/sxNN1KLs

## Why

We need to draft out the design of the Redux store for the advisor work flow as we start getting into implementing it.

## What

- Create an `AdvisorState` interface containing basic session data along a list of students for use in both the students tab and when searching students to assign a template to
- Add the `advisorReducer` along with advisor actions

## Notes

We are currently settling with not persisting data like notifications or templates within the Redux state and requesting them as needed since they are only used in a single location each. Students on the other hand will be cached in Redux after the first request so it can be reused across both the students tab and when assigning templates to students.

Please let us know if there are any concerns with this approach!