### PR TITLE
use shallow equal

### DIFF
--- a/frontend/src/Onboarding/RedirectScreen.tsx
+++ b/frontend/src/Onboarding/RedirectScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Cookies from "js-cookie";
 import { Redirect } from "react-router";
-import { useDispatch, useSelector } from "react-redux";
+import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import { fetchUser } from "../services/UserService";
 import {
   setUserAction,
@@ -60,7 +60,8 @@ export const RedirectScreen: React.FC<Props> = ({ redirectUrl }) => {
       academicYear: getAcademicYearFromState(state),
       graduationYear: getGraduationYearFromState(state),
       isAdvisor: getIsAdvisorFromState(state),
-    })
+    }),
+    shallowEqual
   );
   const [isLoading, setIsLoading] = useState(true);
 

--- a/frontend/src/components/Routes/ProtectedRoute.tsx
+++ b/frontend/src/components/Routes/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { shallowEqual, useSelector } from "react-redux";
 import { Redirect, Route, RouteComponentProps } from "react-router-dom";
 import { RedirectScreen } from "../../Onboarding/RedirectScreen";
 import { getUserIdFromState } from "../../state";
@@ -15,9 +15,12 @@ export function ProtectedRoute({
     | React.ComponentType<any>;
   path: string;
 }) {
-  const { userId } = useSelector((state: AppState) => ({
-    userId: getUserIdFromState(state),
-  }));
+  const { userId } = useSelector(
+    (state: AppState) => ({
+      userId: getUserIdFromState(state),
+    }),
+    shallowEqual
+  );
 
   if (isLoggedIn()) {
     // if user exists in redux


### PR DESCRIPTION
ShallowEqual is necessary for proper rerenders when we use `useSelector` in this way (returning one object with everything), as opposed to one `useSelector` call per field we want from redux.