### PR TITLE
Save null (not empty string) in db for major, coopCycle, catalogYear if blank

### DIFF
--- a/frontend/src/Onboarding/TransferableCreditScreen.tsx
+++ b/frontend/src/Onboarding/TransferableCreditScreen.tsx
@@ -2,9 +2,7 @@ import { Grid, Paper } from "@material-ui/core";
 import React, { useState } from "react";
 import { useDispatch, shallowEqual, useSelector } from "react-redux";
 import { TransferableExam, TransferableExamGroup } from "../../../common/types";
-import {
-  setExamCreditsAction,
-} from "../state/actions/userActions";
+import { setExamCreditsAction } from "../state/actions/userActions";
 import {
   MainTitleText,
   OnboardingSelectionTemplate,
@@ -17,20 +15,23 @@ import { createPlanForUser } from "../services/PlanService";
 import {
   getAcademicYearFromState,
   getGraduationYearFromState,
-  getUserMajorFromState,
+  getUserMajorNameFromState,
   getUserIdFromState,
   getUserCoopCycleFromState,
   getCompletedCoursesFromState,
   getTransferCoursesFromState,
   getUserCatalogYearFromState,
-  getPlansFromState
+  getPlansFromState,
 } from "../state";
 import { AppState } from "../state/reducers/state";
 import { addNewPlanAction } from "../state/actions/userPlansActions";
 import { updateUser } from "../services/UserService";
 import { getAuthToken } from "../utils/auth-helpers";
 import { getSimplifiedCourseData } from "../utils/completed-courses-helpers";
-import { generateInitialSchedule, generateInitialScheduleNoCoopCycle } from "../utils";
+import {
+  generateInitialSchedule,
+  generateInitialScheduleNoCoopCycle,
+} from "../utils";
 
 interface TransferableExamGroupComponentProps {
   readonly transferableExamGroup: TransferableExamGroup;
@@ -158,11 +159,11 @@ const TransferableCreditScreen: React.FC = () => {
     catalogYear,
     completedCourses,
     transferCourses,
-    allPlans
+    allPlans,
   } = useSelector(
     (state: AppState) => ({
       userId: getUserIdFromState(state),
-      major: getUserMajorFromState(state),
+      major: getUserMajorNameFromState(state),
       academicYear: getAcademicYearFromState(state)!,
       graduationYear: getGraduationYearFromState(state)!,
       coopCycle: getUserCoopCycleFromState(state),
@@ -182,13 +183,14 @@ const TransferableCreditScreen: React.FC = () => {
   const onSubmit = (): Promise<any> => {
     dispatch(setExamCreditsAction(selectedTransferableExams));
     const token = getAuthToken();
-      const updateUserPromise = () => updateUser(
+    const updateUserPromise = () =>
+      updateUser(
         {
           id: userId!,
           token: token,
         },
         {
-          major: major?.name,
+          major: major,
           academic_year: academicYear,
           graduation_year: graduationYear,
           coop_cycle: coopCycle,
@@ -205,26 +207,37 @@ const TransferableCreditScreen: React.FC = () => {
         }
       );
 
-      const createPlanPromise = () => {
-        let schedule, courseCounter;
-        if (!!coopCycle) {
-          [schedule, courseCounter] = generateInitialSchedule(academicYear, graduationYear, completedCourses, major!.name, coopCycle!, allPlans);
-        } else {
-          [schedule, courseCounter] = generateInitialScheduleNoCoopCycle(academicYear, graduationYear, completedCourses);
-        }
+    const createPlanPromise = () => {
+      let schedule, courseCounter;
+      if (!!coopCycle) {
+        [schedule, courseCounter] = generateInitialSchedule(
+          academicYear,
+          graduationYear,
+          completedCourses,
+          major!,
+          coopCycle!,
+          allPlans
+        );
+      } else {
+        [schedule, courseCounter] = generateInitialScheduleNoCoopCycle(
+          academicYear,
+          graduationYear,
+          completedCourses
+        );
+      }
 
-        createPlanForUser(userId!, token, {
+      createPlanForUser(userId!, token, {
         name: "Plan 1",
         link_sharing_enabled: false,
         schedule: schedule,
-        major: major ? major.name : "",
-        coop_cycle: coopCycle ? coopCycle : "None",
+        major: major,
+        coop_cycle: coopCycle,
         course_counter: courseCounter,
-        catalog_year: catalogYear
+        catalog_year: catalogYear,
       }).then(response => {
         dispatch(addNewPlanAction(response.plan, academicYear));
       });
-    }
+    };
 
     return Promise.all([updateUserPromise(), createPlanPromise()]);
   };

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -32,12 +32,6 @@ const MajorTitle = styled.p`
   margin-bottom: 12px;
 `;
 
-interface SidebarProps {
-  schedule: DNDSchedule;
-  major: string;
-  transferCourses: ScheduleCourse[];
-}
-
 interface MajorSidebarProps {
   schedule: DNDSchedule;
   major: Major;
@@ -84,14 +78,17 @@ const MajorSidebarComponent: React.FC<MajorSidebarProps> = ({
   );
 };
 
-const SidebarComponent: React.FC<SidebarProps> = ({
-  schedule,
-  major,
-  transferCourses,
-}) => {
-  const majorObj: Major | undefined = useSelector<AppState, Major | undefined>(
-    state => findMajorFromName(major, state.majorState.majors)
+export const Sidebar: React.FC = () => {
+  const { schedule, major, transferCourses } = useSelector(
+    (state: AppState) => ({
+      major: getActivePlanMajorFromState(state),
+      schedule: getActivePlanScheduleFromState(state),
+      transferCourses: getTransferCoursesFromState(state),
+    })
   );
+  const { majorObj } = useSelector((state: AppState) => ({
+    majorObj: findMajorFromName(major, state.majorState.majors),
+  }));
 
   return majorObj ? (
     <MajorSidebarComponent
@@ -103,11 +100,3 @@ const SidebarComponent: React.FC<SidebarProps> = ({
     <NoMajorSidebarComponent />
   );
 };
-
-const mapStateToProps = (state: AppState) => ({
-  schedule: getActivePlanScheduleFromState(state),
-  transferCourses: getTransferCoursesFromState(state),
-  major: getActivePlanMajorFromState(state),
-});
-
-export const Sidebar = connect(mapStateToProps)(SidebarComponent);

--- a/frontend/src/home/EditPlanPopper.tsx
+++ b/frontend/src/home/EditPlanPopper.tsx
@@ -35,8 +35,8 @@ import {
   setActivePlanCoopCycleAction,
   setActivePlanMajorAction,
   setActivePlanDNDScheduleAction,
-  setActivePlanCatalogYearAction,
   setCurrentClassCounterForActivePlanAction,
+  setActivePlanCatalogYearAction,
 } from "../state/actions/userPlansActions";
 
 const PlanPopper = styled(Popper)<any>`
@@ -105,21 +105,21 @@ interface ReduxStoreEditPlanProps {
   allPlans: Record<string, Schedule[]>;
   creditsTaken: number;
   name: string;
-  catalogYear?: number;
+  catalogYear: number | null;
   academicYear: number;
   graduationYear: number;
 }
 
 interface ReduxDispatchEditPlanProps {
   setActivePlanCoopCycle: (
-    coopCycle: string,
+    coopCycle: string | null,
     academicYear: number,
     graduationYear: number,
     allPlans?: Record<string, Schedule[]>
   ) => void;
   setActivePlanDNDSchedule: (schedule: DNDSchedule) => void;
-  setActivePlanMajor: (major: string) => void;
-  setActivePlanCatalogYear: (number: number) => void;
+  setActivePlanMajor: (major: string | null) => void;
+  setActivePlanCatalogYear: (number: number | null) => void;
   setCurrentClassCounter: (counter: number) => void;
 }
 
@@ -184,7 +184,11 @@ export class EditPlanPopperComponent extends React.Component<
   }
 
   onChangeCatalogYear(event: React.SyntheticEvent<{}>, value: any) {
-    this.props.setActivePlanCatalogYear(value);
+    if (value === "") {
+      this.props.setActivePlanCatalogYear(null);
+    } else {
+      this.props.setActivePlanCatalogYear(value);
+    }
   }
 
   renderMajorDropDown() {
@@ -214,7 +218,7 @@ export class EditPlanPopperComponent extends React.Component<
         disableListWrap
         options={[
           "None",
-          ...this.props.allPlans[this.props.plan.major].map(p =>
+          ...this.props.allPlans[this.props.plan.major!].map(p =>
             planToString(p)
           ),
         ]}
@@ -251,7 +255,9 @@ export class EditPlanPopperComponent extends React.Component<
             fullWidth
           />
         )}
-        value={this.props.catalogYear ? this.props.catalogYear + "" : ""}
+        value={
+          this.props.plan.catalogYear ? this.props.plan.catalogYear + "" : ""
+        }
         onChange={this.onChangeCatalogYear.bind(this)}
       />
     );
@@ -271,7 +277,7 @@ export class EditPlanPopperComponent extends React.Component<
     const [schedule, counter] = generateInitialScheduleFromExistingPlan(
       this.props.academicYear,
       this.props.graduationYear,
-      this.props.plan.major,
+      this.props.plan.major!,
       this.props.plan.coopCycle!,
       this.props.allPlans
     );
@@ -340,6 +346,7 @@ export class EditPlanPopperComponent extends React.Component<
               </StandingText>
               {this.renderCatalogYearDropdown()}
               {!!this.props.plan.catalogYear && this.renderMajorDropDown()}
+              {!!this.props.plan.major && this.renderPlansDropDown()}
               {!!this.props.plan.major &&
               !!this.props.plan.coopCycle &&
               !scheduleHasClasses(this.props.plan.schedule)
@@ -368,7 +375,7 @@ const mapStateToProps = (state: AppState) => ({
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   setActivePlanCoopCycle: (
-    coopCycle: string,
+    coopCycle: string | null,
     academicYear: number,
     graduationYear: number,
     allPlans?: Record<string, Schedule[]>
@@ -383,9 +390,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     ),
   setActivePlanDNDSchedule: (schedule: DNDSchedule) =>
     dispatch(setActivePlanDNDScheduleAction(schedule)),
-  setActivePlanMajor: (major: string) =>
+  setActivePlanMajor: (major: string | null) =>
     dispatch(setActivePlanMajorAction(major)),
-  setActivePlanCatalogYear: (year: number) =>
+  setActivePlanCatalogYear: (year: number | null) =>
     dispatch(setActivePlanCatalogYearAction(year)),
   setCurrentClassCounter: (counter: number) =>
     dispatch(setCurrentClassCounterForActivePlanAction(counter)),

--- a/frontend/src/home/Home.tsx
+++ b/frontend/src/home/Home.tsx
@@ -190,8 +190,8 @@ interface ToastHomeProps {
 
 interface ReduxStoreHomeProps {
   transferCredits: ScheduleCourse[];
-  major?: string;
-  coopCycle?: string;
+  major: string | null;
+  coopCycle: string | null;
   warnings: IWarning[];
   userId: number;
   majors: Major[];

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -157,6 +157,7 @@ export interface IUserData {
   fullName: string;
   academicYear: number | null;
   graduationYear: number | null;
+  catalogYear: number | null;
   major: string | null;
   coopCycle: string | null;
   nuId: string;
@@ -164,7 +165,6 @@ export interface IUserData {
   examCredits: TransferableExam[];
   transferCourses: ScheduleCourse[];
   completedCourses: ScheduleCourse[];
-  catalogYear?: number;
 }
 
 /**
@@ -184,13 +184,13 @@ export interface IPlanData {
   name: string;
   linkSharingEnabled: boolean;
   schedule: DNDSchedule;
-  major: string;
-  coopCycle: string;
+  catalogYear: number | null;
+  major: string | null;
+  coopCycle: string | null;
   warnings: IWarning[];
   courseWarnings: CourseWarning[];
   courseCounter: number;
   lastViewed: Date;
-  catalogYear?: number;
 }
 
 /**
@@ -200,12 +200,26 @@ export interface ICreatePlanData {
   name: string;
   link_sharing_enabled: boolean;
   schedule: DNDSchedule;
-  major: string;
-  coop_cycle: string;
+  catalog_year: number | null;
+  major: string | null;
+  coop_cycle: string | null;
   course_counter: number;
-  catalog_year?: number;
   last_viewed?: Date;
 }
+
+export interface IUpdatePlanData {
+  name: string;
+  link_sharing_enabled: boolean;
+  schedule: DNDSchedule;
+  catalog_year: number | null;
+  major: string | null;
+  coop_cycle: string | null;
+  course_counter: number;
+  last_viewed?: Date;
+  warnings: IWarning[];
+  course_warnings: CourseWarning[];
+}
+
 /*
  * Data needed to update a user
  */
@@ -224,8 +238,8 @@ export interface IUpdateUserData {
   academic_year?: number;
   graduation_year?: number;
   coop_cycle?: string | null;
+  catalog_year?: number | null;
   nu_id?: string;
-  catalog_year?: number;
   courses_transfer?: ISimplifiedCourseDataAPI[];
   courses_completed?: ISimplifiedCourseDataAPI[];
 }

--- a/frontend/src/state/actions/userActions.ts
+++ b/frontend/src/state/actions/userActions.ts
@@ -29,21 +29,21 @@ export const setGraduationYearAction = createAction(
 
 export const setUserMajorAction = createAction(
   "user/SET_USER_MAJOR",
-  (major: string) => ({
+  (major: string | null) => ({
     major,
   })
 )();
 
 export const setUserCoopCycleAction = createAction(
   "user/SET_COOP_CYCLE",
-  (coopCycle: string) => ({
+  (coopCycle: string | null) => ({
     coopCycle,
   })
 )();
 
 export const setUserCatalogYearAction = createAction(
   "user/SET_CATALOG",
-  (catalogYear?: number) => ({
+  (catalogYear: number | null) => ({
     catalogYear,
   })
 )();

--- a/frontend/src/state/actions/userPlansActions.ts
+++ b/frontend/src/state/actions/userPlansActions.ts
@@ -49,13 +49,13 @@ export const setActivePlanDNDScheduleAction = createAction(
 
 export const setActivePlanMajorAction = createAction(
   "schedule/SET_ACTIVE_PLAN_MAJOR",
-  (major: string) => ({ major })
+  (major: string | null) => ({ major })
 )();
 
 export const setActivePlanCoopCycleAction = createAction(
   "schedule/SET_ACTIVE_PLAN_COOP_CYCLE",
   (
-    coopCycle: string,
+    coopCycle: string | null,
     academicYear: number,
     graduationYear: number,
     allPlans?: Record<string, Schedule[]>
@@ -69,7 +69,7 @@ export const setActivePlanCoopCycleAction = createAction(
 
 export const setActivePlanCatalogYearAction = createAction(
   "schedule/SET_ACTIVE_PLAN_CATALOG_YEAR",
-  (catalogYear: number, allPlans?: Record<string, Schedule[]>) => ({
+  (catalogYear: number | null, allPlans?: Record<string, Schedule[]>) => ({
     catalogYear,
     allPlans,
   })

--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -61,16 +61,16 @@ export const getUserMajorFromState = (state: AppState): Major | undefined =>
 
 export const getUserCatalogYearFromState = (
   state: AppState
-): number | undefined => getUserFromState(state).catalogYear;
+): number | null => getUserFromState(state).catalogYear;
 
 /**
  * Get the selected major name from the AppState
  * @param state the AppState
  */
-export const getUserMajorNameFromState = (state: AppState) =>
+export const getUserMajorNameFromState = (state: AppState): string | null =>
   getUserFromState(state).major;
 
-export const getUserCoopCycleFromState = (state: AppState) =>
+export const getUserCoopCycleFromState = (state: AppState): string | null =>
   getUserFromState(state).coopCycle;
 
 export const getAcademicYearFromState = (state: AppState) =>

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -24,23 +24,17 @@ import {
   changeSemesterStatusForActivePlanAction,
   updateSemesterForActivePlanAction,
 } from "../actions/userPlansActions";
-import {
-  resetUserAction,
-  setCompletedCoursesAction,
-} from "../actions/userActions";
+import { resetUserAction } from "../actions/userActions";
 import {
   clearSchedule,
   convertTermIdToSeason,
   convertToDNDCourses,
   convertToDNDSchedule,
-  getNextTerm,
   isYearInPast,
-  numToTerm,
   planToString,
   produceWarnings,
-  sumCreditsFromList,
 } from "../../utils";
-import { Schedule, ScheduleCourse } from "../../../../common/types";
+import { Schedule } from "../../../../common/types";
 import { updatePlanForUser } from "../../services/PlanService";
 import { getAuthToken } from "../../utils/auth-helpers";
 
@@ -177,7 +171,7 @@ export const userPlansReducer = (
 
         const activePlan = draft.plans[draft.activePlan!];
 
-        const plan = allPlans[activePlan.major].find(
+        const plan = allPlans[activePlan.major!].find(
           (p: Schedule) => planToString(p) === coopCycle
         );
 


### PR DESCRIPTION
- We should use null instead of undefined/empty string in a lot of places

- Only go to completed courses screen if the user selected a major

- Overhaul onboarding info screen to handle major given from khoury data