### PR TITLE
Set primary plan

### DIFF
--- a/api/app/controllers/plans_controller.rb
+++ b/api/app/controllers/plans_controller.rb
@@ -116,6 +116,20 @@ class PlansController < ApplicationController
     end
   end
 
+  def set_primary
+    if authorized
+        user = User.find_by(id: params[:user_id])
+        if user
+          user.update(primary_plan_id: params[:id])
+          render status: 200, json: @controller.to_json
+        else
+          render json: {error: "No such user."}, status: :unprocessable_entity
+        end
+    else
+        render json: {error: "Unauthorized."}, status: :unprocessable_entity
+    end
+end
+
   private
 
   #parameters

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -21,6 +21,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  nu_id                  :string
+#  primary_plan_id        :bigint(8)
 #
 # Indexes
 #

--- a/api/app/views/users/_user.json.jbuilder
+++ b/api/app/views/users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.(user, :id, :email, :full_name, :academic_year, :graduation_year, :major, :coop_cycle, :is_advisor, :nu_id, :catalog_year, :courses_completed, :courses_transfer)
+json.(user, :id, :email, :full_name, :academic_year, :graduation_year, :major, :coop_cycle, :is_advisor, :nu_id, :catalog_year, :courses_completed, :courses_transfer, :primary_plan_id)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
           put :last_viewed
           put :approve
           put :request_approval
+          put :set_primary
         end
       end
       resources :templates, only: [:index, :create]

--- a/api/db/migrate/20210101193734_add_primary_plan_id_to_user.rb
+++ b/api/db/migrate/20210101193734_add_primary_plan_id_to_user.rb
@@ -1,0 +1,5 @@
+class AddPrimaryPlanIdToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :primary_plan_id, :bigint
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_26_223431) do
+ActiveRecord::Schema.define(version: 2021_01_01_193734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 2020_12_26_223431) do
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "plan_comments", force: :cascade do |t|
+    t.string "author", null: false
+    t.string "comment", null: false
+    t.bigint "plan_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["plan_id"], name: "index_plan_comments_on_plan_id"
   end
 
   create_table "plans", force: :cascade do |t|
@@ -73,6 +82,7 @@ ActiveRecord::Schema.define(version: 2020_12_26_223431) do
     t.string "nu_id"
     t.json "courses_completed", default: [], array: true
     t.json "courses_transfer", default: [], array: true
+    t.bigint "primary_plan_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["full_name"], name: "index_users_on_full_name"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/api/test/fixtures/users.yml
+++ b/api/test/fixtures/users.yml
@@ -21,6 +21,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  nu_id                  :string
+#  primary_plan_id        :bigint(8)
 #
 # Indexes
 #

--- a/api/test/models/user_test.rb
+++ b/api/test/models/user_test.rb
@@ -21,6 +21,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  nu_id                  :string
+#  primary_plan_id        :bigint(8)
 #
 # Indexes
 #

--- a/common/types.ts
+++ b/common/types.ts
@@ -326,15 +326,6 @@ export interface CourseTakenTracker {
   getTermIds: (course: string) => number[];
 }
 
-export interface IUserData {
-  fullName?: string;
-  academicYear?: number;
-  graduationYear?: number;
-  major?: Major;
-  minors?: string[];
-  plan?: Schedule;
-}
-
 /**
  * An enumeration of the different kinds of transferable exams available.
  */

--- a/frontend/src/Onboarding/TransferableCreditScreen.tsx
+++ b/frontend/src/Onboarding/TransferableCreditScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from "./GenericOnboarding";
 import { APExamGroups2020To2021 } from "../../../common/ap_exams";
 import { IBExamGroups2020To2021 } from "../../../common/ib_exams";
-import { createPlanForUser } from "../services/PlanService";
+import { createPlanForUser, setPrimaryPlan } from "../services/PlanService";
 import {
   getAcademicYearFromState,
   getGraduationYearFromState,
@@ -228,6 +228,7 @@ const TransferableCreditScreen: React.FC = () => {
         catalog_year: catalogYear,
       }).then(response => {
         dispatch(addNewPlanAction(response.plan, academicYear));
+        setPrimaryPlan(userId, response.plan.id);
       });
     };
 

--- a/frontend/src/models/types.ts
+++ b/frontend/src/models/types.ts
@@ -162,6 +162,7 @@ export interface IUserData {
   coopCycle: string | null;
   nuId: string;
   isAdvisor: boolean;
+  primaryPlanId?: number;
   examCredits: TransferableExam[];
   transferCourses: ScheduleCourse[];
   completedCourses: ScheduleCourse[];

--- a/frontend/src/services/PlanService.ts
+++ b/frontend/src/services/PlanService.ts
@@ -141,3 +141,12 @@ export const requestApproval = (
       "Content-Type": "application/json",
     },
   }).then(response => response.json());
+
+export const setPrimaryPlan = (userId: number, planId: number) =>
+  fetch(`/api/users/${userId}/plans/${planId}/set_primary`, {
+    method: "PUT",
+    headers: {
+      Authorization: "Token " + getAuthToken(),
+      "Content-Type": "application/json",
+    },
+  }).then(response => response.json());

--- a/frontend/src/state/index.ts
+++ b/frontend/src/state/index.ts
@@ -32,6 +32,9 @@ export const safelyGetUserIdFromState = (state: AppState) =>
 export const getUserFullNameFromState = (state: AppState) =>
   getUserFromState(state).fullName;
 
+export const getUserPrimaryPlanIdFromState = (state: AppState) =>
+  getUserFromState(state).primaryPlanId;
+
 /**
  * Get the list of completed requirements from the AppState
  * @param state the AppState


### PR DESCRIPTION
Allows students to set a primary plan for an advisor. We should iterate on what the best UI is to indicate a primary plan to a user. Maybe we replace "Plan of Study" with "Your Primary Plan" or the plan name if it's not primary? 