### PR TITLE
Add option to create from existing or new folder on TemplateInfoPage

### DIFF
--- a/common/tests/__snapshots__/prereq_loader.test.js.snap
+++ b/common/tests/__snapshots__/prereq_loader.test.js.snap
@@ -2407,7 +2407,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -3467,7 +3466,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -4254,7 +4252,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -4361,7 +4358,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -5082,7 +5078,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -5218,7 +5213,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -5937,7 +5931,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -6058,7 +6051,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -6667,7 +6659,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -6884,7 +6875,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -7336,7 +7326,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -7637,7 +7626,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -7955,9 +7943,17 @@ Object {
           },
           Object {
             "classId": "1156",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Recitation for POLS 1155",
             "numCreditsMax": 0,
             "numCreditsMin": 0,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "POLS",
           },
         ],
@@ -8707,9 +8703,17 @@ Object {
           },
           Object {
             "classId": "1156",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Recitation for POLS 1155",
             "numCreditsMax": 0,
             "numCreditsMin": 0,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "POLS",
           },
         ],
@@ -9654,9 +9658,55 @@ Object {
           },
           Object {
             "classId": "3412",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Language and Culture",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "type": "or",
+                  "values": Array [
+                    Object {
+                      "classId": "1150",
+                      "subject": "LING",
+                    },
+                    Object {
+                      "classId": "1150",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                  ],
+                },
+                Object {
+                  "type": "or",
+                  "values": Array [
+                    Object {
+                      "classId": "1111",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                    Object {
+                      "classId": "1102",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                    Object {
+                      "classId": "1111",
+                      "subject": "ENGW",
+                    },
+                    Object {
+                      "classId": "1102",
+                      "subject": "ENGW",
+                    },
+                  ],
+                },
+              ],
+            },
             "subject": "LING",
           },
           Object {
@@ -9906,7 +9956,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -10137,7 +10186,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -10500,9 +10548,55 @@ Object {
           },
           Object {
             "classId": "3412",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Language and Culture",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "type": "or",
+                  "values": Array [
+                    Object {
+                      "classId": "1150",
+                      "subject": "LING",
+                    },
+                    Object {
+                      "classId": "1150",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                  ],
+                },
+                Object {
+                  "type": "or",
+                  "values": Array [
+                    Object {
+                      "classId": "1111",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                    Object {
+                      "classId": "1102",
+                      "missing": true,
+                      "subject": "ENGL",
+                    },
+                    Object {
+                      "classId": "1111",
+                      "subject": "ENGW",
+                    },
+                    Object {
+                      "classId": "1102",
+                      "subject": "ENGW",
+                    },
+                  ],
+                },
+              ],
+            },
             "subject": "LING",
           },
           Object {
@@ -10737,7 +10831,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -10913,7 +11006,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -18664,7 +18756,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -19521,7 +19612,6 @@ Object {
                 },
                 Object {
                   "classId": "3500",
-                  "missing": true,
                   "subject": "DS",
                 },
               ],
@@ -19871,9 +19961,36 @@ Object {
         "classes": Array [
           Object {
             "classId": "4530",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Media Arts Degree Project 1",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "or",
+              "values": Array [
+                Object {
+                  "classId": "1111",
+                  "missing": true,
+                  "subject": "ENGL",
+                },
+                Object {
+                  "classId": "1102",
+                  "missing": true,
+                  "subject": "ENGL",
+                },
+                Object {
+                  "classId": "1111",
+                  "subject": "ENGW",
+                },
+                Object {
+                  "classId": "1102",
+                  "subject": "ENGW",
+                },
+              ],
+            },
             "subject": "ARTD",
           },
           Object {
@@ -19953,7 +20070,6 @@ Object {
               "values": Array [
                 Object {
                   "classId": "4530",
-                  "missing": true,
                   "subject": "ARTD",
                 },
               ],
@@ -23455,16 +23571,43 @@ Object {
         "classes": Array [
           Object {
             "classId": "1107",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1108",
+                  "missing": true,
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Foundations of Biology",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
             "classId": "1108",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1107",
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Lab for BIOL 1107",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
@@ -23563,9 +23706,17 @@ Object {
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Biochemistry at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOC",
           },
         ],
@@ -23596,7 +23747,6 @@ Object {
                 },
                 Object {
                   "classId": "1107",
-                  "missing": true,
                   "subject": "BIOL",
                 },
                 Object {
@@ -24108,7 +24258,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {
@@ -24240,7 +24389,6 @@ Object {
                     },
                     Object {
                       "classId": "2317",
-                      "missing": true,
                       "subject": "CHEM",
                     },
                   ],
@@ -24394,7 +24542,6 @@ Object {
                     },
                     Object {
                       "classId": "1175",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                   ],
@@ -24605,16 +24752,43 @@ Object {
         "classes": Array [
           Object {
             "classId": "1107",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1108",
+                  "missing": true,
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Foundations of Biology",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
             "classId": "1108",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1107",
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Lab for BIOL 1107",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
@@ -24713,9 +24887,17 @@ Object {
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Biochemistry at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOC",
           },
         ],
@@ -24746,7 +24928,6 @@ Object {
                 },
                 Object {
                   "classId": "1107",
-                  "missing": true,
                   "subject": "BIOL",
                 },
                 Object {
@@ -25309,7 +25490,6 @@ Object {
                     },
                     Object {
                       "classId": "2317",
-                      "missing": true,
                       "subject": "CHEM",
                     },
                   ],
@@ -25387,7 +25567,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {
@@ -25628,7 +25807,6 @@ Object {
                     },
                     Object {
                       "classId": "1175",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                   ],
@@ -25755,16 +25933,43 @@ Object {
         "classes": Array [
           Object {
             "classId": "1107",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1108",
+                  "missing": true,
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Foundations of Biology",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
             "classId": "1108",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1107",
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Lab for BIOL 1107",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
@@ -25863,9 +26068,17 @@ Object {
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Biochemistry at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOC",
           },
         ],
@@ -25896,7 +26109,6 @@ Object {
                 },
                 Object {
                   "classId": "1107",
-                  "missing": true,
                   "subject": "BIOL",
                 },
                 Object {
@@ -26393,7 +26605,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {
@@ -26525,7 +26736,6 @@ Object {
                     },
                     Object {
                       "classId": "2317",
-                      "missing": true,
                       "subject": "CHEM",
                     },
                   ],
@@ -26704,7 +26914,6 @@ Object {
                     },
                     Object {
                       "classId": "1175",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                   ],
@@ -26937,16 +27146,43 @@ Object {
         "classes": Array [
           Object {
             "classId": "1107",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1108",
+                  "missing": true,
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Foundations of Biology",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
             "classId": "1108",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1107",
+                  "subject": "BIOL",
+                },
+              ],
+            },
+            "name": "Lab for BIOL 1107",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOL",
           },
           Object {
@@ -27045,9 +27281,17 @@ Object {
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Biochemistry at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "BIOC",
           },
         ],
@@ -27078,7 +27322,6 @@ Object {
                 },
                 Object {
                   "classId": "1107",
-                  "missing": true,
                   "subject": "BIOL",
                 },
                 Object {
@@ -27626,7 +27869,6 @@ Object {
                     },
                     Object {
                       "classId": "2317",
-                      "missing": true,
                       "subject": "CHEM",
                     },
                   ],
@@ -27704,7 +27946,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {
@@ -27937,7 +28178,6 @@ Object {
                     },
                     Object {
                       "classId": "1175",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                   ],
@@ -28156,23 +28396,88 @@ Object {
           },
           Object {
             "classId": "1161",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1162",
+                  "missing": true,
+                  "subject": "PHYS",
+                },
+                Object {
+                  "classId": "1163",
+                  "missing": true,
+                  "subject": "PHYS",
+                },
+              ],
+            },
+            "name": "Physics 1",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "or",
+              "values": Array [
+                Object {
+                  "classId": "1241",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1251",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1341",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1342",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "2321",
+                  "subject": "MATH",
+                },
+              ],
+            },
             "subject": "PHYS",
           },
           Object {
             "classId": "1162",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1161",
+                  "subject": "PHYS",
+                },
+                Object {
+                  "classId": "1163",
+                  "subject": "PHYS",
+                },
+              ],
+            },
+            "name": "Lab for PHYS 1161",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "PHYS",
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Mathematics at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "MATH",
           },
         ],
@@ -28229,7 +28534,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {
@@ -28841,16 +29145,73 @@ Object {
         "classes": Array [
           Object {
             "classId": "1161",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1162",
+                  "missing": true,
+                  "subject": "PHYS",
+                },
+                Object {
+                  "classId": "1163",
+                  "missing": true,
+                  "subject": "PHYS",
+                },
+              ],
+            },
+            "name": "Physics 1",
             "numCreditsMax": 4,
             "numCreditsMin": 4,
+            "prereqs": Object {
+              "type": "or",
+              "values": Array [
+                Object {
+                  "classId": "1241",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1251",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1341",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "1342",
+                  "subject": "MATH",
+                },
+                Object {
+                  "classId": "2321",
+                  "subject": "MATH",
+                },
+              ],
+            },
             "subject": "PHYS",
           },
           Object {
             "classId": "1162",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [
+                Object {
+                  "classId": "1161",
+                  "subject": "PHYS",
+                },
+                Object {
+                  "classId": "1163",
+                  "subject": "PHYS",
+                },
+              ],
+            },
+            "name": "Lab for PHYS 1161",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "PHYS",
           },
           Object {
@@ -28885,9 +29246,17 @@ Object {
           },
           Object {
             "classId": "1000",
-            "name": "",
+            "coreqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
+            "name": "Mathematics at Northeastern",
             "numCreditsMax": 1,
             "numCreditsMin": 1,
+            "prereqs": Object {
+              "type": "and",
+              "values": Array [],
+            },
             "subject": "MATH",
           },
           Object {
@@ -28951,7 +29320,6 @@ Object {
                     },
                     Object {
                       "classId": "1161",
-                      "missing": true,
                       "subject": "PHYS",
                     },
                     Object {

--- a/frontend/src/advising/Templates/TemplateInfoPage.tsx
+++ b/frontend/src/advising/Templates/TemplateInfoPage.tsx
@@ -30,8 +30,6 @@ import {
   planToString,
 } from "../../utils";
 
-const FOLDER_NAME_FIELD_LABEL = "New folder name";
-
 const Container = styled.div`
   margin-left: 30px;
   margin-right: 30px;
@@ -57,6 +55,14 @@ const ButtonContainer = styled.div`
 `;
 
 const InputContainer = styled.div`
+  width: 326px;
+`;
+
+const FolderSelectionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 25px;
   width: 326px;
 `;
 
@@ -116,7 +122,7 @@ const DisplayedInputField: React.FC<{ creatingNewFolder: boolean }> = ({
       <NameField
         name={newFolderName}
         setName={setNewFolderName}
-        label={FOLDER_NAME_FIELD_LABEL}
+        label={"New folder name"}
       />
     );
   }
@@ -132,7 +138,7 @@ const DisplayedInputField: React.FC<{ creatingNewFolder: boolean }> = ({
           <TextField
             {...params}
             variant="outlined"
-            label={"Save Plan in Folder"}
+            label={"Existing folder"}
             fullWidth
           />
         )}
@@ -156,33 +162,33 @@ const FolderSelection: React.FC<{}> = () => {
       <NameField
         name={newFolderName}
         setName={setNewFolderName}
-        label={FOLDER_NAME_FIELD_LABEL}
+        label={"New folder name"}
       />
     );
   }
 
   return (
-    <div>
+    <FolderSelectionContainer>
       <ButtonGroup color="primary" aria-label="outlined primary button group">
-        <Button
-          disabled={creatingNewFolder}
-          onClick={() => {
-            setCreatingNewFolder(true);
-          }}
-        >
-          Create in existing folder
-        </Button>
         <Button
           disabled={!creatingNewFolder}
           onClick={() => {
             setCreatingNewFolder(false);
           }}
         >
+          Create in existing folder
+        </Button>
+        <Button
+          disabled={creatingNewFolder}
+          onClick={() => {
+            setCreatingNewFolder(true);
+          }}
+        >
           Create in new folder
         </Button>
       </ButtonGroup>
       <DisplayedInputField creatingNewFolder={creatingNewFolder} />
-    </div>
+    </FolderSelectionContainer>
   );
 };
 

--- a/frontend/src/advising/Templates/TemplateInfoPage.tsx
+++ b/frontend/src/advising/Templates/TemplateInfoPage.tsx
@@ -1,4 +1,4 @@
-import { TextField, FormControl, ButtonGroup, Button } from "@material-ui/core";
+import { TextField, FormControl, Tabs, Tab } from "@material-ui/core";
 import { Autocomplete } from "@material-ui/lab";
 import React, { createContext, useContext, useEffect, useMemo } from "react";
 import { useState } from "react";
@@ -62,7 +62,7 @@ const FolderSelectionContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 25px;
+  gap: 5px;
   width: 326px;
 `;
 
@@ -151,11 +151,17 @@ const DisplayedInputField: React.FC<{ creatingNewFolder: boolean }> = ({
 };
 
 const FolderSelection: React.FC<{}> = () => {
-  // TODO: add validation for duplicate folders
-  const [creatingNewFolder, setCreatingNewFolder] = useState(false);
+  // TODO: add validation for duplicate folders, fix validation as a whole lol
+  const [tabValue, setTabValue] = useState(0);
   const { folders, newFolderName, setNewFolderName } = useContext(
     folderContext
   ) as FolderContext;
+
+  const creatingNewFolder = !!tabValue;
+
+  const handleTabChange = (event: React.ChangeEvent<{}>, newValue: number) => {
+    setTabValue(newValue);
+  };
 
   if (folders.length < 1) {
     return (
@@ -169,24 +175,10 @@ const FolderSelection: React.FC<{}> = () => {
 
   return (
     <FolderSelectionContainer>
-      <ButtonGroup color="primary" aria-label="outlined primary button group">
-        <Button
-          disabled={!creatingNewFolder}
-          onClick={() => {
-            setCreatingNewFolder(false);
-          }}
-        >
-          Create in existing folder
-        </Button>
-        <Button
-          disabled={creatingNewFolder}
-          onClick={() => {
-            setCreatingNewFolder(true);
-          }}
-        >
-          Create in new folder
-        </Button>
-      </ButtonGroup>
+      <Tabs value={tabValue} onChange={handleTabChange}>
+        <Tab label="Existing Folder" />
+        <Tab label="New Folder" />
+      </Tabs>
       <DisplayedInputField creatingNewFolder={creatingNewFolder} />
     </FolderSelectionContainer>
   );

--- a/frontend/src/advising/Templates/TemplateInfoPage.tsx
+++ b/frontend/src/advising/Templates/TemplateInfoPage.tsx
@@ -18,7 +18,11 @@ import {
 import { SaveInParentConcentrationDropdown } from "../../components/ConcentrationDropdown";
 import { findMajorFromName } from "../../utils/plan-helpers";
 import { IFolderData } from "../../models/types";
-import { createTemplate, getTemplates } from "../../services/TemplateService";
+import {
+  createTemplate,
+  getTemplates,
+  TemplatesAPI,
+} from "../../services/TemplateService";
 import {
   getAdvisorUserIdFromState,
   getMajorsFromState,
@@ -242,13 +246,12 @@ export const NewTemplatesPage: React.FC<RouteComponentProps<{}>> = ({
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
   const [newFolderName, setNewFolderName] = useState<string>("");
 
-  const fetchTemplates = async () => {
-    try {
-      const { templates } = await getTemplates(userId, "", 0);
-      setFolders(templates);
-    } catch (e) {
-      console.log(e);
-    }
+  const fetchTemplates = () => {
+    getTemplates(userId, "", 0)
+      .then((response: TemplatesAPI) => {
+        setFolders(response.templates);
+      })
+      .catch((err: any) => console.log(err));
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Why

We need a way for advisors to create new folders.

## What

- Replace the existing existing folder selection on the `TemplateInfoPage` with a new `FolderSelection` component that provides the option to either choose an existing folder or create a new folder

## Notes

- For the future, I'm going to also revamp the error handling on this page to match that of the other pages, i.e. having individual errors for each form that display when pressing next
- There is some minor styling wonkiness when switching between inputs (they have different heights)
- We are definitely going to need to think about providing the option to delete folders as well + what the intricacies of that are going to be
- We eventually will want to give the option to create an empty folder from the list page