### PR TITLE
sort validation based on group type

### DIFF
--- a/frontend/src/utils/generate-warnings.ts
+++ b/frontend/src/utils/generate-warnings.ts
@@ -249,9 +249,6 @@ export function produceRequirementGroupWarning(
   );
 
   for (const requirementGroup of sortedRequirements) {
-    // todo: if req group is RangeSection or contains a ICourseRange process after all other requirement groups.
-    // this is because these reqs can be satisfied by a wide range of courses, and you don't want it using up
-    // a course that is need to satisfy a more constrained requirement.
     let unsatisfiedRequirement:
       | IRequirementGroupWarning
       | undefined = produceUnsatifiedRequirement(

--- a/frontend/src/utils/generate-warnings.ts
+++ b/frontend/src/utils/generate-warnings.ts
@@ -30,6 +30,7 @@ import {
   Season,
   StatusEnum,
 } from "../../../common/types";
+import { sortOnValues } from "./requirementGroupUtils";
 /*
 CreditRange interface to track the min and max credits for a particular season.
 seasonMax = a number representing the max numebr of credits you can take without over-loading.
@@ -241,11 +242,13 @@ export function produceRequirementGroupWarning(
     }
   }
 
-  let requirementGroups: string[] = major.requirementGroups;
   let res: IRequirementGroupWarning[] = [];
-  for (const name of requirementGroups) {
-    let requirementGroup: IMajorRequirementGroup =
-      major.requirementGroupMap[name];
+
+  const sortedRequirements = sortOnValues(
+    Object.values(major.requirementGroupMap)
+  );
+
+  for (const requirementGroup of sortedRequirements) {
     // todo: if req group is RangeSection or contains a ICourseRange process after all other requirement groups.
     // this is because these reqs can be satisfied by a wide range of courses, and you don't want it using up
     // a course that is need to satisfy a more constrained requirement.

--- a/frontend/src/utils/requirementGroupUtils.ts
+++ b/frontend/src/utils/requirementGroupUtils.ts
@@ -3,10 +3,10 @@ import { IMajorRequirementGroup } from "../../../common/types";
 const reqGroupSortOrder = ["AND", "OR", "RANGE"];
 
 /**
- *
+ * sorts the IMajorRequirementGroups by the group constrain from most to least constrained
  * @param groupMap Mapping of section name to IMajorRequirementGroup validation group
  */
-export const sortOnValues = (
+export const sortRequirementGroupsByConstraint = (
   reqGroupArray: IMajorRequirementGroup[]
 ): IMajorRequirementGroup[] =>
   // Sort the array based on the IMajorRequirementGroup type
@@ -15,13 +15,7 @@ export const sortOnValues = (
       const diff =
         reqGroupSortOrder.indexOf(first.type) -
         reqGroupSortOrder.indexOf(second.type);
-      if (diff < 0) {
-        return -1;
-      }
-      if (diff > 0) {
-        return 1;
-      } else {
-        return 0;
-      }
+      // returns 0 if diff 0, -1 if diff negative, and 1 if diff positive
+      return Math.min(1, Math.max(-1, diff));
     }
   );

--- a/frontend/src/utils/requirementGroupUtils.ts
+++ b/frontend/src/utils/requirementGroupUtils.ts
@@ -1,0 +1,27 @@
+import { IMajorRequirementGroup } from "../../../common/types";
+
+const reqGroupSortOrder = ["AND", "OR", "RANGE"];
+
+/**
+ *
+ * @param groupMap Mapping of section name to IMajorRequirementGroup validation group
+ */
+export const sortOnValues = (
+  reqGroupArray: IMajorRequirementGroup[]
+): IMajorRequirementGroup[] =>
+  // Sort the array based on the IMajorRequirementGroup type
+  reqGroupArray.sort(
+    (first: IMajorRequirementGroup, second: IMajorRequirementGroup): number => {
+      const diff =
+        reqGroupSortOrder.indexOf(first.type) -
+        reqGroupSortOrder.indexOf(second.type);
+      if (diff < 0) {
+        return -1;
+      }
+      if (diff > 0) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  );


### PR DESCRIPTION
This is a subtask on this ticket: https://trello.com/c/rkcjckMU/30-update-requirement-group-validation-in-the-sidebar

Sort the requirement groups based on type of IMajorRequirementGroup, from most to least constrained, with most being AND and least being RANGE. 

Example use case for sorting is that we'd want to validation concentration courses before validating electives