### PR TITLE
Fix 100% width for folder name on TemplateInfoPage

### DIFF
--- a/frontend/src/advising/Templates/TemplateInfoPage.tsx
+++ b/frontend/src/advising/Templates/TemplateInfoPage.tsx
@@ -116,7 +116,7 @@ const NameField: React.FC<NameFieldProps> = ({
       value={name}
       onChange={event => setName(event.target.value)}
       placeholder=""
-      style={{ width: "100%" }}
+      style={{ width: "326px" }}
       error={error}
     />
   );


### PR DESCRIPTION
## Why 

There is an issue with how the folder name input field looks if the advisor has no existing folders. This was because the field's width property was set to 100%.

## What
Sets a static width of 326px for the input field to match the other fields.