### PR TITLE
Add additional co-op cycle options 

### DIFF
--- a/frontend/src/Onboarding/OnboardingInfoScreen.tsx
+++ b/frontend/src/Onboarding/OnboardingInfoScreen.tsx
@@ -47,6 +47,7 @@ import { createPlanForUser, setPrimaryPlan } from "../services/PlanService";
 import { addNewPlanAction } from "../state/actions/userPlansActions";
 import { IPlanData, ITemplatePlan } from "../models/types";
 import { DisclaimerPopup } from "../components/common/DisclaimerPopup";
+import { BASE_FORMATTED_COOP_CYCLES } from "../plans/coopCycles";
 
 const SpinnerWrapper = styled.div`
   display: flex;
@@ -369,7 +370,7 @@ class OnboardingScreenComponent extends React.Component<
       <Autocomplete
         style={{ width: 326, marginBottom: marginSpace }}
         disableListWrap
-        options={this.props.plans[this.state.major!].map(p => planToString(p))}
+        options={BASE_FORMATTED_COOP_CYCLES}
         renderInput={params => (
           <TextField
             {...params}

--- a/frontend/src/home/EditPlanPopper.tsx
+++ b/frontend/src/home/EditPlanPopper.tsx
@@ -47,6 +47,7 @@ import {
   SnackbarAlert,
   ALERT_STATUS,
 } from "../components/common/SnackbarAlert";
+import { BASE_FORMATTED_COOP_CYCLES } from "../plans/coopCycles";
 
 const PlanPopper = styled(Popper)<any>`
   margin-top: 4px;
@@ -232,12 +233,7 @@ export class EditPlanPopperComponent extends React.Component<
       <Autocomplete
         style={{ marginTop: "10px", marginBottom: "15px", fontSize: "10px" }}
         disableListWrap
-        options={[
-          "None",
-          ...this.props.allPlans[this.props.plan.major!].map(p =>
-            planToString(p)
-          ),
-        ]}
+        options={["None", ...BASE_FORMATTED_COOP_CYCLES]}
         renderInput={params => (
           <TextField
             {...params}
@@ -282,6 +278,14 @@ export class EditPlanPopperComponent extends React.Component<
   }
 
   renderSetClassesButton() {
+    const examplePlanExists = this.props.allPlans[
+      this.props.plan.major || ""
+    ].some((p: Schedule) => planToString(p) === this.props.plan.coopCycle);
+
+    if (!examplePlanExists) {
+      return;
+    }
+
     return (
       <ButtonContainer>
         <SetButton

--- a/frontend/src/plans/coopCycles.ts
+++ b/frontend/src/plans/coopCycles.ts
@@ -5,27 +5,30 @@ const NUM_YEARS_AND_COOPS_OPTIONS: { numYears: number; numCoops: number }[] = [
   { numYears: 4, numCoops: 2 },
 ];
 
-const SEASON_ENUM_TO_TITLE: Record<SeasonEnum, string> = {
+const SEASON_ENUM_TO_TITLE: Record<string, string> = {
   [SeasonEnum.FL]: "Fall",
   [SeasonEnum.SP]: "Spring",
   [SeasonEnum.SM]: "Summer",
-  [SeasonEnum.S1]: "Summer 1",
-  [SeasonEnum.S2]: "Summer 2",
 };
+
+const isValidCoopCycleSeason = (season: SeasonEnum): boolean =>
+  season !== SeasonEnum.S1 && season !== SeasonEnum.S2;
 
 /**'
  * This is the basic set of co-op cycle options which can be selected for any major.
  * It consists of:
- * - 5 years, 3 co-ops, spring/fall/summer/summer1/summer2
- * - 4 years, 3 co-ops, spring/fall/summer/summer1/summer2
+ * - 5 years, 3 co-ops, spring/fall/summer
+ * - 4 years, 3 co-ops, spring/fall/summer
  */
 export const BASE_FORMATTED_COOP_CYCLES: string[] = NUM_YEARS_AND_COOPS_OPTIONS.map(
   option =>
-    Object.values(SeasonEnum).map((season: SeasonEnum) => {
-      return (
-        `${option.numYears} Years, ` +
-        `${option.numCoops} Co-ops, ` +
-        `${SEASON_ENUM_TO_TITLE[season]} Cycle`
-      );
-    })
+    Object.values(SeasonEnum)
+      .filter(isValidCoopCycleSeason)
+      .map((season: string) => {
+        return (
+          `${option.numYears} Years, ` +
+          `${option.numCoops} Co-ops, ` +
+          `${SEASON_ENUM_TO_TITLE[season]} Cycle`
+        );
+      })
 ).reduce((acc, coopCyclesPerOption) => [...acc, ...coopCyclesPerOption], []);

--- a/frontend/src/plans/coopCycles.ts
+++ b/frontend/src/plans/coopCycles.ts
@@ -1,0 +1,29 @@
+import { SeasonEnum } from "../models/types";
+
+const NUM_YEARS_AND_COOPS_OPTIONS: { numYears: number; numCoops: number }[] = [
+  { numYears: 5, numCoops: 3 },
+  { numYears: 4, numCoops: 2 },
+];
+
+const SEASON_ENUM_TO_TITLE: Record<SeasonEnum, string> = {
+  [SeasonEnum.FL]: "Fall",
+  [SeasonEnum.SP]: "Spring",
+  [SeasonEnum.SM]: "Summer",
+  [SeasonEnum.S1]: "Summer 1",
+  [SeasonEnum.S2]: "Summer 2",
+};
+
+/**'
+ * This is the basic set of co-op cycle options which can be selected for any major.
+ * It consists of:
+ * - 5 years, 3 co-ops, spring/fall/summer/summer1/summer2
+ * - 4 years, 3 co-ops, spring/fall/summer/summer1/summer2
+ */
+export const BASE_FORMATTED_COOP_CYCLES: string[] = NUM_YEARS_AND_COOPS_OPTIONS.map(
+  option =>
+    Object.values(SeasonEnum).map((season: SeasonEnum) => {
+      return `${option.numYears} Years, 
+      ${option.numCoops} Co-ops, 
+      ${SEASON_ENUM_TO_TITLE[season]} Cycle`;
+    })
+).reduce((acc, coopCyclesPerOption) => [...acc, ...coopCyclesPerOption], []);

--- a/frontend/src/plans/coopCycles.ts
+++ b/frontend/src/plans/coopCycles.ts
@@ -22,8 +22,10 @@ const SEASON_ENUM_TO_TITLE: Record<SeasonEnum, string> = {
 export const BASE_FORMATTED_COOP_CYCLES: string[] = NUM_YEARS_AND_COOPS_OPTIONS.map(
   option =>
     Object.values(SeasonEnum).map((season: SeasonEnum) => {
-      return `${option.numYears} Years, 
-      ${option.numCoops} Co-ops, 
-      ${SEASON_ENUM_TO_TITLE[season]} Cycle`;
+      return (
+        `${option.numYears} Years, ` +
+        `${option.numCoops} Co-ops, ` +
+        `${SEASON_ENUM_TO_TITLE[season]} Cycle`
+      );
     })
 ).reduce((acc, coopCyclesPerOption) => [...acc, ...coopCyclesPerOption], []);

--- a/frontend/src/profile/Profile.tsx
+++ b/frontend/src/profile/Profile.tsx
@@ -27,6 +27,7 @@ import { IUpdateUser, IUpdateUserData } from "../models/types";
 import { getAuthToken } from "../utils/auth-helpers";
 import { SaveInParentConcentrationDropdown } from "../components/ConcentrationDropdown";
 import { findMajorFromName } from "../utils/plan-helpers";
+import { BASE_FORMATTED_COOP_CYCLES } from "../plans/coopCycles";
 
 const OuterContainer = styled.div`
   width: 70%;
@@ -256,7 +257,7 @@ const ProfileComponent: React.FC = () => {
         {isEdit && (
           <Autocomplete
             disableListWrap
-            options={plans[major!].map((p: Schedule) => planToString(p))}
+            options={BASE_FORMATTED_COOP_CYCLES}
             renderInput={params => (
               <TextField {...params} variant="outlined" fullWidth />
             )}

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -199,23 +199,22 @@ export const userPlansReducer = (
           (p: Schedule) => planToString(p) === coopCycle
         );
 
-        if (!plan) {
-          return draft;
+        if (plan) {
+          const [newSchedule, newCounter] = convertToDNDSchedule(
+            plan,
+            activePlan.courseCounter
+          );
+
+          // remove all classes
+          draft.plans[
+            draft.activePlan!
+          ].schedule = alterScheduleToHaveCorrectYears(
+            clearSchedule(newSchedule),
+            academicYear,
+            graduationYear
+          );
         }
 
-        const [newSchedule, newCounter] = convertToDNDSchedule(
-          plan,
-          activePlan.courseCounter
-        );
-
-        // remove all classes
-        draft.plans[
-          draft.activePlan!
-        ].schedule = alterScheduleToHaveCorrectYears(
-          clearSchedule(newSchedule),
-          academicYear,
-          graduationYear
-        );
         draft.plans[draft.activePlan!].courseCounter = 0;
 
         // clear all warnings

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -205,15 +205,19 @@ export const userPlansReducer = (
             activePlan.courseCounter
           );
 
-          // remove all classes
           draft.plans[
             draft.activePlan!
           ].schedule = alterScheduleToHaveCorrectYears(
-            clearSchedule(newSchedule),
+            newSchedule,
             academicYear,
             graduationYear
           );
         }
+
+        // remove all classes
+        draft.plans[draft.activePlan!].schedule = clearSchedule(
+          draft.plans[draft.activePlan!].schedule
+        );
 
         draft.plans[draft.activePlan!].courseCounter = 0;
 

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -189,6 +189,10 @@ export const userPlansReducer = (
           graduationYear,
         } = action.payload;
 
+        if (!coopCycle) {
+          return;
+        }
+
         if (!allPlans) {
           return draft;
         }


### PR DESCRIPTION
[Ticket](https://trello.com/c/5ST3Q0EJ)

## Why

We want users to be able to select co-op cycles that don't have a corresponding plan.

## What
- Compute and export a static constant which contains co-op cycle options
- Use these options in co-op cycle dropdowns
- In the `EditPlanPopper`, conditionally display the `SET EXAMPLE SCHEDULE` button based upon if there is an available schedule

## Notes
- This only exposes the new co-op cycles and allows them to be selected and persisted, schedules are not yet able to update to match them (I was told this would be future work)
- I did not add this to the `AddPlanPopper` because of the above point