### PR TITLE
Fixed typo

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -90,7 +90,7 @@ export interface IAndCourse {
 export interface ICourseRange {
   type: "RANGE";
   creditsRequired: number;
-  // Potentially add a min/mas to ICourseRange
+  // Potentially add a min/max to ICourseRange
   ranges: ISubjectRange[];
 }
 


### PR DESCRIPTION
The word max was misspelled as mas