### PR TITLE
Add student transfer to redux

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,9 +17,8 @@ import { RedirectScreen } from "./Onboarding/RedirectScreen";
 import { ProtectedRoute } from "./components/Routes/ProtectedRoute";
 import { UnprotectedRoute } from "./components/Routes/UnprotectedRoute";
 import { StudentsList } from "./advising/ManageStudents/StudentsList";
-import { StudentView } from "./advising/ManageStudents/StudentView";
-import { ExpandedStudentView } from "./advising/ManageStudents/ExpandedStudentView";
 import { TemplateBuilderPage } from "./advising/Templates/TemplateBuilderPage";
+import { GenericStudentView } from "./advising/ManageStudents/GenericStudentView";
 
 export const App = ({ store }: { store: Store }) => {
   return (
@@ -65,13 +64,11 @@ const AdvisorRouter = (props: any) => {
         <Route exact path={`${path}/manageStudents`} component={StudentsList} />
         <Route
           exact
-          path={`${path}/manageStudents/:id`}
-          component={StudentView}
-        />
-        <Route
-          exact
-          path={`${path}/manageStudents/:id/expanded/:planId`}
-          component={ExpandedStudentView}
+          path={[
+            `${path}/manageStudents/:id`,
+            `${path}/manageStudents/:id/expanded/:planId`,
+          ]}
+          component={GenericStudentView}
         />
         <Route exact path={`${path}/templates`} component={TemplatesListPage} />
         <Route

--- a/frontend/src/advising/ManageStudents/ExpandedStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/ExpandedStudentView.tsx
@@ -150,7 +150,7 @@ export const ExpandedStudentView: React.FC<ExpandedStudentViewProps> = ({
       sendPlanUpdates();
       window.removeEventListener("beforeunload", sendPlanUpdates);
     };
-  }, []);
+  }, [user]);
 
   const callUpdatePlanLastViewedOnInterval = () => {
     if (interval) {

--- a/frontend/src/advising/ManageStudents/ExpandedStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/ExpandedStudentView.tsx
@@ -24,7 +24,6 @@ import { PlanTitle, ButtonHeader, ScheduleWrapper, Container } from "./Shared";
 import { Prompt, useHistory, useLocation, useParams } from "react-router";
 import { IUserData } from "../../models/types";
 import { fetchUser } from "../../services/AdvisorService";
-import { Comments } from "../../components/Schedule/Comments";
 import {
   approvePlanForUser,
   fetchPlan,
@@ -32,7 +31,10 @@ import {
 } from "../../services/PlanService";
 import IdleTimer from "react-idle-timer";
 import { LoadingSpinner } from "../../components/common/LoadingSpinner";
-import { setStudentAction } from "../../state/actions/studentActions";
+import {
+  setStudentAction,
+  setTransferCoursesAction,
+} from "../../state/actions/studentActions";
 import { Alert } from "@material-ui/lab";
 import { PrimaryButton } from "../../components/common/PrimaryButton";
 import {
@@ -41,6 +43,7 @@ import {
 } from "../../components/common/SnackbarAlert";
 import ScheduleChangeTracker from "../../utils/ScheduleChangeTracker";
 import { sendChangeLog } from "../../services/PlanService";
+import { getScheduleCoursesFromSimplifiedCourseDataAPI } from "../../utils/course-helpers";
 
 const FullScheduleViewContainer = styled.div`
   margin-top: 30px;
@@ -123,13 +126,23 @@ export const ExpandedStudentView: React.FC = () => {
         fetchPlan(studentId, planId)
           .then(response => {
             callUpdatePlanLastViewedOnInterval();
-            batch(() => {
-              dispatch(setStudentAction(user));
-              dispatch(setUserPlansAction([response], user.academicYear));
-              dispatch(
-                setActivePlanAction(response.name, studentId, user.academicYear)
-              );
+            getScheduleCoursesFromSimplifiedCourseDataAPI(
+              user.coursesTransfer
+            ).then(courses => {
+              batch(() => {
+                dispatch(setStudentAction(user));
+                dispatch(setUserPlansAction([response], user.academicYear));
+                dispatch(
+                  setActivePlanAction(
+                    response.name,
+                    studentId,
+                    user.academicYear
+                  )
+                );
+                dispatch(setTransferCoursesAction(courses));
+              });
             });
+
             setStudent(user);
             setLoading(false);
           })

--- a/frontend/src/advising/ManageStudents/GenericStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/GenericStudentView.tsx
@@ -32,6 +32,17 @@ export const GenericStudentView: React.FC = () => {
     "/advisor/manageStudents/:id/expanded/:planId"
   );
 
+  /**
+   * CURRENT ISSUE:
+   * When refreshing on the expanded student view, the user is not properly being re-fetched,
+   * causing any usages to show up undefined.
+   *
+   * We are expecting that on refresh, the following useEffect will re-fetch the user, set it
+   * within local state, and pass that result to the ExpandedStudentView, but it doesn't seem
+   * like this is the case. We have confirmed from the network request to fetch the student is
+   * still being made. However, as soon as we try to reference it, it is undefined.
+   */
+
   useEffect(() => {
     fetchUser(userId).then(response => {
       const user = response.user;

--- a/frontend/src/advising/ManageStudents/GenericStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/GenericStudentView.tsx
@@ -15,6 +15,12 @@ interface ParamProps {
   planId: string; // id of the student's plan
 }
 
+/**
+ * This component represents a standard or expanded student view within the advisor workflow.
+ * The reason for this abstraction is in order to share data across both of these views and
+ * properly clean up set state when navigating away from either.
+ * @returns
+ */
 export const GenericStudentView: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState<any>();

--- a/frontend/src/advising/ManageStudents/GenericStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/GenericStudentView.tsx
@@ -32,17 +32,6 @@ export const GenericStudentView: React.FC = () => {
     "/advisor/manageStudents/:id/expanded/:planId"
   );
 
-  /**
-   * CURRENT ISSUE:
-   * When refreshing on the expanded student view, the user is not properly being re-fetched,
-   * causing any usages to show up undefined.
-   *
-   * We are expecting that on refresh, the following useEffect will re-fetch the user, set it
-   * within local state, and pass that result to the ExpandedStudentView, but it doesn't seem
-   * like this is the case. We have confirmed from the network request to fetch the student is
-   * still being made. However, as soon as we try to reference it, it is undefined.
-   */
-
   useEffect(() => {
     fetchUser(userId).then(response => {
       const user = response.user;

--- a/frontend/src/advising/ManageStudents/GenericStudentView.tsx
+++ b/frontend/src/advising/ManageStudents/GenericStudentView.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { batch, useDispatch } from "react-redux";
+import { useParams, useRouteMatch } from "react-router";
+import { fetchUser } from "../../services/AdvisorService";
+import {
+  setStudentAction,
+  setTransferCoursesAction,
+} from "../../state/actions/studentActions";
+import { getScheduleCoursesFromSimplifiedCourseDataAPI } from "../../utils/course-helpers";
+import { ExpandedStudentView } from "./ExpandedStudentView";
+import { StudentView } from "./StudentView";
+
+interface ParamProps {
+  id: string; // id of the student
+  planId: string; // id of the student's plan
+}
+
+export const GenericStudentView: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<any>();
+  const dispatch = useDispatch();
+  const params = useParams<ParamProps>();
+  const userId = Number(params.id);
+
+  const isExpanded = !!useRouteMatch(
+    "/advisor/manageStudents/:id/expanded/:planId"
+  );
+
+  useEffect(() => {
+    fetchUser(userId).then(response => {
+      const user = response.user;
+
+      getScheduleCoursesFromSimplifiedCourseDataAPI(user.coursesTransfer).then(
+        courses => {
+          batch(() => {
+            dispatch(setStudentAction(user));
+            dispatch(setTransferCoursesAction(courses));
+          });
+
+          setLoading(false);
+        }
+      );
+
+      setUser(user);
+    });
+
+    return () => {
+      // Clear the student.
+      dispatch(setStudentAction());
+    };
+  }, []);
+
+  if (isExpanded) {
+    return <ExpandedStudentView user={user} />;
+  }
+
+  return <StudentView user={user} fetchingStudent={loading} />;
+};

--- a/frontend/src/advising/ManageStudents/StudentView.tsx
+++ b/frontend/src/advising/ManageStudents/StudentView.tsx
@@ -85,6 +85,7 @@ const StudentInfoTextWrapper = styled.div`
   > * {
   }
 `;
+
 const Text = styled.div`
   font-size: 12px;
   font-weight: normal;

--- a/frontend/src/advising/ManageStudents/StudentView.tsx
+++ b/frontend/src/advising/ManageStudents/StudentView.tsx
@@ -9,6 +9,7 @@ import {
 import {
   safelyGetActivePlanIdFromState,
   getActivePlanNameFromState,
+  getStudentFromState,
 } from "../../state";
 import {
   addNewPlanAction,
@@ -165,6 +166,7 @@ export const StudentView: React.FC = () => {
   const { planName, planId } = useSelector((state: AppState) => ({
     planName: getActivePlanNameFromState(state),
     planId: safelyGetActivePlanIdFromState(state),
+    student: getStudentFromState(state),
   }));
 
   useEffect(() => {

--- a/frontend/src/components/Schedule/ScheduleComponents.tsx
+++ b/frontend/src/components/Schedule/ScheduleComponents.tsx
@@ -26,7 +26,7 @@ import {
   getCurrentClassCounterFromState,
   getActivePlanFromState,
   safelyGetTransferCoursesFromState,
-  getUserIdFromState,
+  safelyGetUserIdFromState,
 } from "../../state";
 import { Year } from "../Year";
 import { TransferCredits } from "../TransferCreditHolder";
@@ -140,7 +140,7 @@ export const NonEditableScheduleStudentView: React.FC<Props> = props => {
       activePlan: getActivePlanFromState(state)!.schedule,
       transferCredits: safelyGetTransferCoursesFromState(state),
       planId: getActivePlanFromState(state)!.id,
-      userId: commentsPresent ? getUserIdFromState(state) : null,
+      userId: commentsPresent ? safelyGetUserIdFromState(state) : null,
     }),
     shallowEqual
   );
@@ -193,7 +193,7 @@ export const EditableSchedule: React.FC<Props> = props => {
       planId: getActivePlanFromState(state)!.id,
       currentClassCounter: getCurrentClassCounterFromState(state),
       transferCredits: safelyGetTransferCoursesFromState(state),
-      userId: commentsPresent ? getUserIdFromState(state) : null,
+      userId: commentsPresent ? safelyGetUserIdFromState(state) : null,
     }),
     shallowEqual
   );

--- a/frontend/src/state/actions/studentActions.ts
+++ b/frontend/src/state/actions/studentActions.ts
@@ -8,7 +8,7 @@ import { IUserData } from "../../models/types";
 
 export const setStudentAction = createAction(
   "student/SET_USER",
-  (student: IUserData) => ({
+  (student?: IUserData) => ({
     student,
   })
 )();

--- a/frontend/src/state/reducers/studentReducer.ts
+++ b/frontend/src/state/reducers/studentReducer.ts
@@ -45,12 +45,18 @@ export const studentReducer = (
       case getType(setStudentAction): {
         draft.student = action.payload.student;
         // TODO: remove these once backend is hooked up for completed/transfer courses
+
+        if (!draft.student) {
+          return draft;
+        }
+
         if (draft.student.completedCourses === undefined) {
           draft.student.completedCourses = [];
         }
         if (draft.student.transferCourses === undefined) {
           draft.student.transferCourses = [];
         }
+
         return draft;
       }
       case getType(setStudentMajorAction): {


### PR DESCRIPTION
Display the transfer credits a student has taken by adding student to redux.
- Abstracted Student View and Expanded Student View into Generic Student View component
- Reduces number of API calls by keeping student in the redux state between the Student View and Expanded Student View
- Removes the student from the state when navigating away from the Student View and Expanded Student View

https://trello.com/c/S61Y7NXW/314-add-student-transfer-courses-to-redux-when-advisor-selects-them