### PR TITLE
Plan Parser Fix

### DIFF
--- a/common/tests/prereq_loader.test.js
+++ b/common/tests/prereq_loader.test.js
@@ -60,7 +60,7 @@ async function testScheduleLinkPrereqs(link) {
   jest.setTimeout(10000);
 
   const page = await rp(link);
-  const schedules = plan_parser.planOfStudyToSchedule(page);
+  const schedules = await plan_parser.planOfStudyToSchedule(page);
 
   const enhancedSchedules = await prereq_loader.addPrereqsToSchedules(
     schedules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "js-cookie": "^2.2.1",
     "js-levenshtein": "^1.1.6",
     "lodash": "^4.17.20",
+    "node-fetch": "^2.6.1",
     "react": "^16.12.0",
     "react-apollo": "^3.1.3",
     "react-beautiful-dnd": "^11.0.5",

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -33,7 +33,7 @@ export const fetchCourse = async (
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       query: `{ 
-        class(subject: "${subject}", classId: ${classId}) {
+        class(subject: "${subject}", classId: "${classId}") {
           latestOccurrence {
             name
             subject

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -8,6 +8,7 @@ interface SearchResult {
   type: string;
   class?: SearchClass;
 }
+const fetch = require("node-fetch");
 
 interface SearchClass {
   name: string;

--- a/scrapers/package.json
+++ b/scrapers/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@types/request-promise": "^4.1.44",
     "cross-env": "5.0.5",
-    "dataloader": "^1.4.0"
+    "dataloader": "^1.4.0",
+    "ts-node": "^9.1.1"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.13",

--- a/scrapers/src/plan_parser.ts
+++ b/scrapers/src/plan_parser.ts
@@ -37,10 +37,6 @@ export async function planOfStudyToSchedule(
   return await Promise.all(schedules);
 }
 
-//every time we set a plan: look up all the courses and set in schedule
-//in the parser, make the API call.
-//while parsing, after the course is don eit should get the name of teh course
-
 /**
  * Builds a schedule from the table information.
  * @param $ the page
@@ -244,7 +240,6 @@ async function addCourses(
             i += 1;
           } else {
             // we have a random elective.
-
             produced.push({
               classId: "9999",
               subject: "XXXX",
@@ -285,7 +280,6 @@ async function buildYear(
   seasons: Array<Array<ScheduleCourse | string>>
 ): Promise<ScheduleYear> {
   // seasons array is not always 4! could be 3 (no summer 2), or 5 (including summer full, as 5th).
-
   const seasonEnums: Season[] = [
     SeasonEnum.FL,
     SeasonEnum.SP,

--- a/scrapers/src/run_parser
+++ b/scrapers/src/run_parser
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+require('ts-node/register');
+require('./plan_parser.ts');

--- a/scrapers/test/catalog_scraper.test.js
+++ b/scrapers/test/catalog_scraper.test.js
@@ -2,7 +2,8 @@ var catalogToMajor = require("../src/catalog-scraper/catalog_scraper.ts");
 
 var fs = require("fs");
 const rp = require("request-promise");
-const plan_parser = require("../src/plan_parser.ts");
+const plan_parser = require();
+("../src/plan_parser.ts");
 const majors = require("../../common/constants");
 const { supported2018_2019, supported2019_2020, supported2020_2021 } = majors;
 
@@ -25,7 +26,7 @@ test("ensure that catalog_scraper produces the expected output for supported maj
 });
 
 async function createObject(acc, link, major) {
-  const plansOfStudy = plan_parser.planOfStudyToSchedule(await rp(link));
+  const plansOfStudy = await plan_parser.planOfStudyToSchedule(await rp(link));
   const { yearVersion } = major;
   const id = link
     .replace("/#programrequirementstext", "")

--- a/scrapers/test/plan_parser.test.js
+++ b/scrapers/test/plan_parser.test.js
@@ -113,7 +113,7 @@ test("ensure that supported majors are still correct, unchanged.", async () => {
   const plans = supported.map(link => rp(link));
 
   for (plan of plans) {
-    const schedules = plan_parser.planOfStudyToSchedule(await plan);
+    const schedules = await plan_parser.planOfStudyToSchedule(await plan);
     expect(schedules).toMatchSnapshot();
   }
 });
@@ -132,7 +132,7 @@ function runTestsOnLinks(links) {
     test(
       "Ensures that scraper correctly converts plan of study no. " + index,
       async () => {
-        const schedules = plan_parser.planOfStudyToSchedule(await plan);
+        const schedules = await plan_parser.planOfStudyToSchedule(await plan);
         expect(schedules).toBeValidModernScheduleList();
       }
     );


### PR DESCRIPTION
Missing names from set example schedule button now being scraped properly. 

To run scraper: 
`ts-node scrapers/src/plan_parser.ts`