### PR TITLE
Ensure that all co-op cycles are used/validated when creating from existing plans

### DIFF
--- a/frontend/src/home/AddPlanPopper.tsx
+++ b/frontend/src/home/AddPlanPopper.tsx
@@ -17,13 +17,15 @@ import { connect } from "react-redux";
 import { AppState } from "../state/reducers/state";
 import { Dispatch } from "redux";
 import { Major, Schedule, ScheduleCourse } from "../../../common/types";
-import { findMajorFromName } from "../utils/plan-helpers";
+import {
+  findExamplePlanFromCoopCycle,
+  findMajorFromName,
+} from "../utils/plan-helpers";
 import { addPrereqsToSchedule } from "../../../common/prereq_loader";
 import Loader from "react-loader-spinner";
 import { createPlanForUser } from "../services/PlanService";
 import {
   convertToDNDSchedule,
-  planToString,
   generateInitialSchedule,
   generateInitialScheduleNoCoopCycle,
   generateInitialScheduleFromExistingPlan,
@@ -45,6 +47,7 @@ import { NextButton } from "../components/common/NextButton";
 import { RedColorButton } from "../components/common/ColoredButtons";
 import { getAuthToken } from "../utils/auth-helpers";
 import { SaveInParentConcentrationDropdown } from "../components/ConcentrationDropdown";
+import { BASE_FORMATTED_COOP_CYCLES } from "../plans/coopCycles";
 
 const EXCEL_TOOLTIP =
   "Auto-populate your schedule with your excel plan of study. Reach out to your advisor if you don't have it!";
@@ -381,7 +384,7 @@ function AddPlanPopperComponent(props: Props) {
     return (
       <Autocomplete
         disableListWrap
-        options={allPlans[selectedMajor!.name].map(p => planToString(p))}
+        options={BASE_FORMATTED_COOP_CYCLES}
         renderInput={params => (
           <TextField
             {...params}
@@ -404,6 +407,15 @@ function AddPlanPopperComponent(props: Props) {
     const setSelect = (e: any) => {
       setSelectedPlanOption(e.target.value);
     };
+
+    const examplePlanExists =
+      selectedMajor &&
+      selectedCoopCycle &&
+      findExamplePlanFromCoopCycle(
+        allPlans,
+        selectedMajor.name,
+        selectedCoopCycle
+      );
 
     const error = showErrors && noPlanBasedOnError;
 
@@ -435,7 +447,7 @@ function AddPlanPopperComponent(props: Props) {
           <MenuItem value={PLAN_OPTIONS.NEW_PLAN}>
             {PLAN_OPTIONS.NEW_PLAN}
           </MenuItem>
-          {selectedCoopCycle && (
+          {examplePlanExists && (
             <MenuItem value={PLAN_OPTIONS.EXAMPLE_PLAN}>
               {PLAN_OPTIONS.EXAMPLE_PLAN}
             </MenuItem>

--- a/frontend/src/home/EditPlanPopper.tsx
+++ b/frontend/src/home/EditPlanPopper.tsx
@@ -49,6 +49,7 @@ import {
   ALERT_STATUS,
 } from "../components/common/SnackbarAlert";
 import { BASE_FORMATTED_COOP_CYCLES } from "../plans/coopCycles";
+import { findExamplePlanFromCoopCycle } from "../utils/plan-helpers";
 
 const PlanPopper = styled(Popper)<any>`
   margin-top: 4px;
@@ -283,9 +284,14 @@ export class EditPlanPopperComponent extends React.Component<
   }
 
   renderSetClassesButton() {
-    const examplePlanExists = this.props.allPlans[
-      this.props.plan.major || ""
-    ].some((p: Schedule) => planToString(p) === this.props.plan.coopCycle);
+    const examplePlanExists =
+      this.props.plan.major &&
+      this.props.plan.coopCycle &&
+      findExamplePlanFromCoopCycle(
+        this.props.allPlans,
+        this.props.plan.major,
+        this.props.plan.coopCycle
+      );
 
     if (!examplePlanExists) {
       return;


### PR DESCRIPTION
https://trello.com/c/X7SrCXb9

## Why

There was another place where example schedules were made based upon co-op cycle and major on the `AddPlanPopper` which wasn't accounted for. This area needs to both use the additional co-op cycles and make sure to only allow creating from example plans where applicable. 

## What

- Use an existing helper function for determining whether there's an existing example plan for a major/co-op cycle
- Use `BASE_FORMATTED_COOP_CYCLES` on the `AddPlanPopper`
- Add logic to the `AddPlanPopper` to only show the `EXISTING_PLAN` option if one exists for the selected major and co-op cycle