### PR TITLE
Stop schedule from being wiped when changing Co-op cycle

### DIFF
--- a/frontend/src/components/ClassBlocks/ClassBlock.tsx
+++ b/frontend/src/components/ClassBlocks/ClassBlock.tsx
@@ -108,8 +108,8 @@ export class ClassBlock extends React.Component<
     if (this.props.warnings) {
       return (
         <div>
-          {this.props.warnings.map(warning => (
-            <div>{warning.message}</div>
+          {this.props.warnings.map((warning, idx) => (
+            <div key={idx}>{warning.message}</div>
           ))}
         </div>
       );

--- a/frontend/src/components/SemesterBlock.tsx
+++ b/frontend/src/components/SemesterBlock.tsx
@@ -9,7 +9,6 @@ import {
   CourseWarning,
   DNDScheduleCourse,
   IWarning,
-  DNDSchedule,
   StatusEnum,
 } from "../models/types";
 import { ScheduleCourse, Status, SeasonWord } from "../../../common/types";
@@ -41,8 +40,6 @@ import {
 } from "../utils/schedule-helpers";
 import { UndoDelete } from "./UndoDelete";
 import ScheduleChangeTracker from "../utils/ScheduleChangeTracker";
-import { type } from "os";
-import { StatusCodeError } from "request-promise/errors";
 
 const OutsideContainer = styled.div`
   width: 25%;

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -122,12 +122,13 @@ const ConcentrationComponent: React.FC<ConcentrationProps> = ({
       <ConcentrationTitle>{userConcentration} Concentration</ConcentrationTitle>
       {concentration?.requirementGroups?.map((req, index) => {
         return (
-          <ConcentrationRequirementGroup>
+          <ConcentrationRequirementGroup
+            key={`${index}-${userConcentration}-${req}`}
+          >
             <RequirementSection
               title={req}
               contents={concentration.requirementGroupMap[req]}
               warning={warnings.find(w => w.requirementGroup === req)}
-              key={`${index}-${userConcentration}-${req}`}
               completedCourses={completedCourseStrings}
               isEditable={isEditable}
             />

--- a/frontend/src/components/Year/YearTop.tsx
+++ b/frontend/src/components/Year/YearTop.tsx
@@ -158,7 +158,7 @@ class YearTopComponent extends React.Component<Props, YearTopState> {
     return (
       <Container>
         {semesters.map(semester => (
-          <div style={textContainerStyle}>
+          <div style={textContainerStyle} key={semester}>
             <SemesterText>
               {semesterMapping[semester]}{" "}
               {semester === "fall" ? year - 1 : year}

--- a/frontend/src/home/Home.tsx
+++ b/frontend/src/home/Home.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import "./Scrollbar.css";
-import {
-  DNDSchedule,
-  IWarning,
-  DNDScheduleTerm,
-  IPlanData,
-} from "../models/types";
-import { Major, SeasonWord, ScheduleCourse } from "../../../common/types";
+import { IWarning, IPlanData } from "../models/types";
+import { Major, ScheduleCourse } from "../../../common/types";
 import styled from "styled-components";
 import { convertTermIdToYear } from "../utils";
 import { withToast } from "./toastHook";

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -235,8 +235,12 @@ export const userPlansReducer = (
           return draft;
         }
 
-        // active plan name should always be definied
-        const activePlanName = draft.activePlan || "";
+        // active plan name should always be defined
+        const activePlanName = draft.activePlan;
+
+        if (!activePlanName) {
+          return draft;
+        }
 
         const activePlan = draft.plans[activePlanName];
         const previousSchedule = draft.plans[activePlanName].schedule;

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -235,8 +235,11 @@ export const userPlansReducer = (
           return draft;
         }
 
-        const activePlan = draft.plans[draft.activePlan!];
-        const previousSchedule = draft.plans[draft.activePlan!].schedule;
+        // active plan name should always be definied
+        const activePlanName = draft.activePlan || "";
+
+        const activePlan = draft.plans[activePlanName];
+        const previousSchedule = draft.plans[activePlanName].schedule;
 
         // find plan with the active plan's major and provided coopCycle
         const plan = allPlans[activePlan.major!].find(
@@ -254,36 +257,36 @@ export const userPlansReducer = (
             graduationYear
           );
 
-          draft.plans[draft.activePlan!].schedule = newScheduleWithCorrectYears;
+          draft.plans[activePlanName].schedule = newScheduleWithCorrectYears;
         }
 
         // remove all classes
-        draft.plans[draft.activePlan!].schedule = clearSchedule(
-          draft.plans[draft.activePlan!].schedule
+        draft.plans[activePlanName].schedule = clearSchedule(
+          draft.plans[activePlanName!].schedule
         );
 
         // fill in the empty schedule using the previous schedule and the cache for the fifth year
         const { filledInSchedule, updatedFifthYearCache } = fillInSchedule(
           previousSchedule,
-          draft.plans[draft.activePlan!].schedule,
-          draft.fifthYearCache[draft.activePlan!]
+          draft.plans[activePlanName].schedule,
+          draft.fifthYearCache[activePlanName]
         );
 
-        draft.plans[draft.activePlan!].schedule = filledInSchedule;
+        draft.plans[activePlanName].schedule = filledInSchedule;
 
         // if the 5th year was removed, store it in the cache
         if (updatedFifthYearCache) {
-          draft.fifthYearCache[draft.activePlan!] = updatedFifthYearCache;
+          draft.fifthYearCache[activePlanName] = updatedFifthYearCache;
         }
 
-        draft.plans[draft.activePlan!].courseCounter = 0;
+        draft.plans[activePlanName].courseCounter = 0;
 
         // clear all warnings
-        draft.plans[draft.activePlan!].warnings = [];
-        draft.plans[draft.activePlan!].courseWarnings = [];
+        draft.plans[activePlanName].warnings = [];
+        draft.plans[activePlanName].courseWarnings = [];
 
         // set the coop cycle
-        draft.plans[draft.activePlan!].coopCycle = coopCycle;
+        draft.plans[activePlanName].coopCycle = coopCycle;
 
         return draft;
       }

--- a/frontend/src/state/reducers/userPlansReducer.ts
+++ b/frontend/src/state/reducers/userPlansReducer.ts
@@ -37,6 +37,7 @@ import {
   convertTermIdToSeason,
   convertToDNDCourses,
   convertToDNDSchedule,
+  copySchedule,
   isYearInPast,
   planToString,
   produceWarnings,
@@ -225,28 +226,35 @@ export const userPlansReducer = (
         }
 
         const activePlan = draft.plans[draft.activePlan!];
+        const previousSchedule = draft.plans[draft.activePlan!].schedule;
 
+        // find plan with the active plan's major and provided coopCycle
         const plan = allPlans[activePlan.major!].find(
           (p: Schedule) => planToString(p) === coopCycle
         );
 
         if (plan) {
-          const [newSchedule, newCounter] = convertToDNDSchedule(
+          const [newSchedule] = convertToDNDSchedule(
             plan,
             activePlan.courseCounter
           );
-
-          draft.plans[
-            draft.activePlan!
-          ].schedule = alterScheduleToHaveCorrectYears(
+          const newScheduleWithCorrectYears = alterScheduleToHaveCorrectYears(
             newSchedule,
             academicYear,
             graduationYear
           );
+
+          draft.plans[draft.activePlan!].schedule = newScheduleWithCorrectYears;
         }
 
         // remove all classes
         draft.plans[draft.activePlan!].schedule = clearSchedule(
+          draft.plans[draft.activePlan!].schedule
+        );
+
+        // copy over classes from previous plan
+        draft.plans[draft.activePlan!].schedule = copySchedule(
+          previousSchedule,
           draft.plans[draft.activePlan!].schedule
         );
 

--- a/frontend/src/utils/deepCopy.ts
+++ b/frontend/src/utils/deepCopy.ts
@@ -1,0 +1,3 @@
+export const deepCopy = <T>(original: T): T => {
+  return JSON.parse(JSON.stringify(original));
+};

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "../models/types";
 import { Schedule, ScheduleCourse, SeasonWord } from "../../../common/types";
 import { findExamplePlanFromCoopCycle } from "./plan-helpers";
+import { deepCopy } from "./deepCopy";
 
 export function generateBlankCoopPlan(
   major: string,
@@ -170,8 +171,8 @@ export function generateBlankCompletedCourseScheduleNoCoopCycle(
     yearsTaken !== 0
       ? completedCourseSchedule.years[yearsTaken - 1]
       : graduationYear - yearsLeft + 1;
-  const completedCourseScheduleCopy = JSON.parse(
-    JSON.stringify(completedCourseSchedule)
+  const completedCourseScheduleCopy = deepCopy(
+    completedCourseSchedule
   ) as Schedule;
   for (let i = 1; i <= yearsLeft; i++) {
     const currentYear = mostRecentYear + i;
@@ -386,7 +387,7 @@ export const convertToDNDSchedule = (
   schedule: Schedule,
   counter: number
 ): [DNDSchedule, number] => {
-  const newSchedule = JSON.parse(JSON.stringify(schedule)) as DNDSchedule;
+  const newSchedule = deepCopy(schedule) as DNDSchedule;
   for (const year of Object.keys(schedule.yearMap)) {
     var result = convertToDNDCourses(
       newSchedule.yearMap[year as any].fall.classes as ScheduleCourse[],
@@ -420,9 +421,9 @@ export const convertToDNDSchedule = (
 };
 
 export const clearSchedule = (schedule: DNDSchedule) => {
-  const yearMapCopy = JSON.parse(JSON.stringify(schedule.yearMap));
+  const yearMapCopy = deepCopy(schedule.yearMap);
   for (const y of schedule.years) {
-    const year = JSON.parse(JSON.stringify(schedule.yearMap[y]));
+    const year = deepCopy(schedule.yearMap[y]);
     year.fall.classes = [];
     year.spring.classes = [];
     year.summer1.classes = [];
@@ -457,13 +458,10 @@ export const fillInSchedule = (
   updatedFifthYearCache?: DNDScheduleYear;
 } => {
   // copy over the first 4 years from previous schedule into current schedule
-  const filledInYearMap = JSON.parse(JSON.stringify(currentSchedule.yearMap));
+  const filledInYearMap = deepCopy(currentSchedule.yearMap);
   for (let i = 0; i < 4; i++) {
     const yearNum = previousSchedule.years[i];
-    const yearCopy = {
-      ...previousSchedule.yearMap[yearNum],
-    };
-
+    const yearCopy = deepCopy(previousSchedule.yearMap[yearNum]);
     filledInYearMap[yearNum] = yearCopy;
   }
 
@@ -474,26 +472,20 @@ export const fillInSchedule = (
 
   // if there is a 5th year in the previous schedule and in the current schedule, copy it over
   if (previousScheduleYears === 5 && currentScheduleYears === 5) {
-    const fifthYearSceduleCopy = {
-      ...previousSchedule.yearMap[fifthYear],
-    };
+    const fifthYearSceduleCopy = deepCopy(previousSchedule.yearMap[fifthYear]);
     filledInYearMap[fifthYear] = fifthYearSceduleCopy;
   }
 
   // if there is a 5th year in the previous schedule but not in the current schedule, copy into cache
   let updatedFifthYearCache: DNDScheduleYear | undefined = undefined;
   if (previousScheduleYears === 5 && currentScheduleYears === 4) {
-    updatedFifthYearCache = {
-      ...previousSchedule.yearMap[fifthYear],
-    };
+    updatedFifthYearCache = deepCopy(previousSchedule.yearMap[fifthYear]);
   }
 
   // if the previous schedule is 4 years but current schedule is 5 years, then copy 5th year from cache
   if (previousScheduleYears === 4 && currentScheduleYears === 5) {
     if (fifthYearCache) {
-      const fifthYearCacheCopy = {
-        ...fifthYearCache,
-      };
+      const fifthYearCacheCopy = deepCopy(fifthYearCache);
       filledInYearMap[fifthYear] = fifthYearCacheCopy;
     }
   }

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -468,10 +468,10 @@ export const fillInSchedule = (
   // use and update the fifth year cache if needed
   const previousScheduleYears = previousSchedule.years.length;
   const currentScheduleYears = currentSchedule.years.length;
-  const fifthYear = previousSchedule.years[4];
 
   // if there is a 5th year in the previous schedule and in the current schedule, copy it over
   if (previousScheduleYears === 5 && currentScheduleYears === 5) {
+    const fifthYear = previousSchedule.years[4];
     const fifthYearSceduleCopy = deepCopy(previousSchedule.yearMap[fifthYear]);
     filledInYearMap[fifthYear] = fifthYearSceduleCopy;
   }
@@ -479,12 +479,14 @@ export const fillInSchedule = (
   // if there is a 5th year in the previous schedule but not in the current schedule, copy into cache
   let updatedFifthYearCache: DNDScheduleYear | undefined = undefined;
   if (previousScheduleYears === 5 && currentScheduleYears === 4) {
+    const fifthYear = previousSchedule.years[4];
     updatedFifthYearCache = deepCopy(previousSchedule.yearMap[fifthYear]);
   }
 
   // if the previous schedule is 4 years but current schedule is 5 years, then copy 5th year from cache
   if (previousScheduleYears === 4 && currentScheduleYears === 5) {
     if (fifthYearCache) {
+      const fifthYear = currentSchedule.years[4];
       const fifthYearCacheCopy = deepCopy(fifthYearCache);
       filledInYearMap[fifthYear] = fifthYearCacheCopy;
     }

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -437,6 +437,28 @@ export const clearSchedule = (schedule: DNDSchedule) => {
   return newSchedule;
 };
 
+export const copySchedule = (
+  previousSchedule: DNDSchedule,
+  currentSchedule: DNDSchedule
+): DNDSchedule => {
+  // copy over the first 4 years from previous schedule into current schedule
+  const yearMapCopy = JSON.parse(JSON.stringify(currentSchedule.yearMap));
+  for (let yearNumIdx = 0; yearNumIdx < 4; yearNumIdx++) {
+    const yearNum = previousSchedule.years[yearNumIdx];
+    const yearCopy = JSON.parse(
+      JSON.stringify(previousSchedule.yearMap[yearNum])
+    );
+    yearMapCopy[yearNum] = yearCopy;
+  }
+
+  const newSchedule: DNDSchedule = {
+    yearMap: yearMapCopy,
+    years: currentSchedule.years,
+  };
+
+  return newSchedule;
+};
+
 export const convertToDNDCourses = (
   courses: ScheduleCourse[],
   counter: number

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -460,9 +460,10 @@ export const fillInSchedule = (
   const filledInYearMap = JSON.parse(JSON.stringify(currentSchedule.yearMap));
   for (let i = 0; i < 4; i++) {
     const yearNum = previousSchedule.years[i];
-    const yearCopy = JSON.parse(
-      JSON.stringify(previousSchedule.yearMap[yearNum])
-    );
+    const yearCopy = {
+      ...previousSchedule.yearMap[yearNum],
+    };
+
     filledInYearMap[yearNum] = yearCopy;
   }
 
@@ -473,24 +474,26 @@ export const fillInSchedule = (
 
   // if there is a 5th year in the previous schedule and in the current schedule, copy it over
   if (previousScheduleYears === 5 && currentScheduleYears === 5) {
-    const fifthYearSceduleCopy = JSON.parse(
-      JSON.stringify(previousSchedule.yearMap[fifthYear])
-    );
+    const fifthYearSceduleCopy = {
+      ...previousSchedule.yearMap[fifthYear],
+    };
     filledInYearMap[fifthYear] = fifthYearSceduleCopy;
   }
 
   // if there is a 5th year in the previous schedule but not in the current schedule, copy into cache
   let updatedFifthYearCache: DNDScheduleYear | undefined = undefined;
   if (previousScheduleYears === 5 && currentScheduleYears === 4) {
-    updatedFifthYearCache = JSON.parse(
-      JSON.stringify(previousSchedule.yearMap[fifthYear])
-    );
+    updatedFifthYearCache = {
+      ...previousSchedule.yearMap[fifthYear],
+    };
   }
 
   // if the previous schedule is 4 years but current schedule is 5 years, then copy 5th year from cache
   if (previousScheduleYears === 4 && currentScheduleYears === 5) {
     if (fifthYearCache) {
-      const fifthYearCacheCopy = JSON.parse(JSON.stringify(fifthYearCache));
+      const fifthYearCacheCopy = {
+        ...fifthYearCache,
+      };
       filledInYearMap[fifthYear] = fifthYearCacheCopy;
     }
   }

--- a/frontend/src/utils/schedule-helpers.ts
+++ b/frontend/src/utils/schedule-helpers.ts
@@ -434,29 +434,73 @@ export const clearSchedule = (schedule: DNDSchedule) => {
     yearMap: yearMapCopy,
     years: schedule.years,
   };
+
   return newSchedule;
 };
 
-export const copySchedule = (
+/**
+ * Fill in the empty schedule using the previous schedule and the cache
+ * for the fifth year. Used to persist schedule when the co-op cycle for a plan
+ * is changed.
+ * @param previousSchedule the schedule prior to the switch in co-op cycle
+ * @param currentSchedule the new empty schedule
+ * @param fifthYearCache the most recent 5th year schedule planned by the user
+ * which is useful for populating the 5th year if the user is swithing back
+ * to a 5 year plan from 4 years.
+ */
+export const fillInSchedule = (
   previousSchedule: DNDSchedule,
-  currentSchedule: DNDSchedule
-): DNDSchedule => {
+  currentSchedule: DNDSchedule,
+  fifthYearCache: DNDScheduleYear
+): {
+  filledInSchedule: DNDSchedule;
+  updatedFifthYearCache?: DNDScheduleYear;
+} => {
   // copy over the first 4 years from previous schedule into current schedule
-  const yearMapCopy = JSON.parse(JSON.stringify(currentSchedule.yearMap));
-  for (let yearNumIdx = 0; yearNumIdx < 4; yearNumIdx++) {
-    const yearNum = previousSchedule.years[yearNumIdx];
+  const filledInYearMap = JSON.parse(JSON.stringify(currentSchedule.yearMap));
+  for (let i = 0; i < 4; i++) {
+    const yearNum = previousSchedule.years[i];
     const yearCopy = JSON.parse(
       JSON.stringify(previousSchedule.yearMap[yearNum])
     );
-    yearMapCopy[yearNum] = yearCopy;
+    filledInYearMap[yearNum] = yearCopy;
   }
 
-  const newSchedule: DNDSchedule = {
-    yearMap: yearMapCopy,
+  // use and update the fifth year cache if needed
+  const previousScheduleYears = previousSchedule.years.length;
+  const currentScheduleYears = currentSchedule.years.length;
+  const fifthYear = previousSchedule.years[4];
+
+  // if there is a 5th year in the previous schedule and in the current schedule, copy it over
+  if (previousScheduleYears === 5 && currentScheduleYears === 5) {
+    const fifthYearSceduleCopy = JSON.parse(
+      JSON.stringify(previousSchedule.yearMap[fifthYear])
+    );
+    filledInYearMap[fifthYear] = fifthYearSceduleCopy;
+  }
+
+  // if there is a 5th year in the previous schedule but not in the current schedule, copy into cache
+  let updatedFifthYearCache: DNDScheduleYear | undefined = undefined;
+  if (previousScheduleYears === 5 && currentScheduleYears === 4) {
+    updatedFifthYearCache = JSON.parse(
+      JSON.stringify(previousSchedule.yearMap[fifthYear])
+    );
+  }
+
+  // if the previous schedule is 4 years but current schedule is 5 years, then copy 5th year from cache
+  if (previousScheduleYears === 4 && currentScheduleYears === 5) {
+    if (fifthYearCache) {
+      const fifthYearCacheCopy = JSON.parse(JSON.stringify(fifthYearCache));
+      filledInYearMap[fifthYear] = fifthYearCacheCopy;
+    }
+  }
+
+  const filledInSchedule: DNDSchedule = {
+    yearMap: filledInYearMap,
     years: currentSchedule.years,
   };
 
-  return newSchedule;
+  return { filledInSchedule, updatedFifthYearCache };
 };
 
 export const convertToDNDCourses = (


### PR DESCRIPTION
## Why are these changes needed?
Currently, if you spend hours working on your schedule and have an epiphany that you want to change the co-op cycle, you basically loose EVERYTHING without any warning whatsoever. We need to change this so that people don't rage and throw their machines out the window.

## What changed?

https://user-images.githubusercontent.com/30478978/139556447-eeb4a274-25d5-40c2-b891-58d363a803dd.mov

- The reducer responsible for handling the change co-op cycle action now fills in the new schedule with the schedule the user has already created. This is done using the `fillInSchedule` helper function in schedule-helpers.ts
- A new map was added to the UserPlansState. It maps a plan name to its fifth year cache. The fifthYearCache is the most recently planned fifth year schedule and is handy to fill in the 5th year when the user goes from 4 to 5 and back to 5.
- Some minor clean up and bug fixes caused by not having the react key prop when rendering lists 

## How are the changes tests?
- Manual browser testing with the following scenarios
  - going from a originally 4 year plan with classes to 5 year plan and then going back to the 4 year plan
  - going from a originally 5 year plan with classes to 4 year plan and then going back to the 5 year plan
  - going from a originally 4 year plan with classes to 5 year plan, adding classes to summer which was previously a vacation and then going back to the 4 year plan(ensuring the classes in the previously vacation summer are also carried forward)
  - going from a originally 4 year plan with classes to 5 year plan, adding classes to 5th year, going to a 4 year plan, and finally going back to the 5 year plan
  - going from a originally 5 year plan with classes to 4 year plan, adding classes to random semesters, going to a 4 year plan, and finally going back to the 5 year plan