### PR TITLE
fix search classes bug

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -72,7 +72,7 @@ export const searchCourses = async (
     body: JSON.stringify({
       query: `
       {
-        search(termId:202130, query: "${searchQuery}", classIdRange: {min: ${minIndex}, max: ${maxIndex}}) {
+        search(termId:"202130", query: "${searchQuery}", classIdRange: {min: ${minIndex}, max: ${maxIndex}}) {
            totalCount 
            pageInfo { hasNextPage } 
            nodes { ... on ClassOccurrence { name subject maxCredits minCredits prereqs coreqs classId


### PR DESCRIPTION
# Description

There was a bug requesting classes from the search api, with the following error
<img width="1438" alt="Screen Shot 2021-12-10 at 5 39 11 PM" src="https://user-images.githubusercontent.com/48878676/145650369-7bb5031f-7008-412d-bec8-6d7bed52ac59.png">




## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Manual testing: 
clicked "+ Add Class" button and searched for class. Before, the page is stuck in loading and in the network tab we see errors. 
After this fix, classes are successfully fetched. 


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed 
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

