### PR TITLE
Fix redeploy script path in aws cd workflow

### DIFF
--- a/.github/workflows/aws-cd.yml
+++ b/.github/workflows/aws-cd.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           # - create new revision for task definition with latest image.
           # - redeploy ECS services with the latest revision.
-          ./infrastructure/deploy/redeploy.sh staging
+          ./infrastructure/prod/redeploy.sh staging
 
       - name: Logout of Amazon ECR
         if: always()

--- a/.github/workflows/aws-cd.yml
+++ b/.github/workflows/aws-cd.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - fix-cd-redeploy-path
+      - main
 
 name: Deploy containers to Amazon ECS
 

--- a/.github/workflows/aws-cd.yml
+++ b/.github/workflows/aws-cd.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - main
+      - fix-cd-redeploy-path
 
 name: Deploy containers to Amazon ECS
 


### PR DESCRIPTION
# Description

Broke CD workflow with the yarn workspaces PR. More specifically, renamed the deploy directory to prod but didn't rename it in the aws workflow 😔

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Updated CD branch name to current branch to run the workflow - https://github.com/sandboxnu/graduatenu/runs/5653699101

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
