### PR TITLE
Add toasts, logging, and error boundary

### DIFF
--- a/packages/frontend-v2/components/Error/ClientSideError.tsx
+++ b/packages/frontend-v2/components/Error/ClientSideError.tsx
@@ -1,0 +1,12 @@
+export const ClientSideError: React.FC = () => {
+  return (
+    <>
+      <div>
+        <h1>GraduateNU</h1>
+      </div>
+      <div>
+        <p>There was an error rendering your page.</p>
+      </div>
+    </>
+  );
+};

--- a/packages/frontend-v2/components/Error/ErrorBoundary.tsx
+++ b/packages/frontend-v2/components/Error/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import { ErrorBoundary as ReactErrorBoundary } from "react-error-boundary";
+import { logger } from "../../utils/logger";
+import { ClientSideError } from "./ClientSideError";
+
+const clientSideErrorHandler = (
+  error: Error,
+  { componentStack }: { componentStack: string }
+) => {
+  logger.error(error.message, componentStack);
+};
+
+export const ErrorBoundary: React.FC = ({ children }) => {
+  return (
+    <ReactErrorBoundary
+      FallbackComponent={ClientSideError}
+      onError={clientSideErrorHandler}
+    >
+      {children}
+    </ReactErrorBoundary>
+  );
+};

--- a/packages/frontend-v2/components/Error/index.ts
+++ b/packages/frontend-v2/components/Error/index.ts
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from "./ErrorBoundary";

--- a/packages/frontend-v2/components/index.ts
+++ b/packages/frontend-v2/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./Error";

--- a/packages/frontend-v2/package.json
+++ b/packages/frontend-v2/package.json
@@ -12,7 +12,9 @@
     "@graduate/common": "workspace:*",
     "next": "12.1.4",
     "react": "18.0.0",
-    "react-dom": "18.0.0"
+    "react-dom": "18.0.0",
+    "react-error-boundary": "^3.1.4",
+    "react-toastify": "^8.2.0"
   },
   "devDependencies": {
     "@types/eslint": "^8",

--- a/packages/frontend-v2/pages/_app.tsx
+++ b/packages/frontend-v2/pages/_app.tsx
@@ -1,3 +1,4 @@
+import "react-toastify/dist/ReactToastify.min.css";
 import Head from "next/head";
 import type { AppProps } from "next/app";
 import { ToastContainer } from "react-toastify";

--- a/packages/frontend-v2/pages/_app.tsx
+++ b/packages/frontend-v2/pages/_app.tsx
@@ -1,6 +1,7 @@
-import "../styles/globals.css";
 import Head from "next/head";
 import type { AppProps } from "next/app";
+import { ToastContainer } from "react-toastify";
+import { ErrorBoundary } from "../components";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -13,7 +14,10 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Component {...pageProps} />
+      <ErrorBoundary>
+        <Component {...pageProps} />
+      </ErrorBoundary>
+      <ToastContainer position="bottom-right" />
     </>
   );
 }

--- a/packages/frontend-v2/pages/index.tsx
+++ b/packages/frontend-v2/pages/index.tsx
@@ -1,4 +1,3 @@
-import "react-toastify/dist/ReactToastify.min.css";
 import type { NextPage } from "next";
 import { toast, logger } from "../utils";
 import { useState } from "react";

--- a/packages/frontend-v2/pages/index.tsx
+++ b/packages/frontend-v2/pages/index.tsx
@@ -1,22 +1,105 @@
+import "react-toastify/dist/ReactToastify.min.css";
 import type { NextPage } from "next";
-import { SeasonEnum } from "@graduate/common";
+import { toast, logger } from "../utils";
+import { useState } from "react";
+import { ClientSideError } from "../components/Error/ClientSideError";
 
 const Home: NextPage = () => {
-  // using a type from our common package
-  const seasons: SeasonEnum[] = [
-    SeasonEnum.FL,
-    SeasonEnum.SP,
-    SeasonEnum.S1,
-    SeasonEnum.S2,
-  ];
+  const [isClientSideError, setIsClientSideError] = useState(false);
+
+  if (isClientSideError) {
+    return <ClientSideError />;
+  }
 
   return (
     <>
       <h1>GraduateNU Landing Page:</h1>
-      <h2>Seasons typed using types from our common package!</h2>
-      {seasons.map((season) => (
-        <p key={season}>{season}</p>
-      ))}
+      <div>
+        <h2>API Error Handling</h2>
+        <div>
+          <h3>Toasts without logging</h3>
+          <button
+            onClick={() =>
+              toast.info("Oh btw here's some info on what you were doing")
+            }
+          >
+            info
+          </button>
+          <button
+            onClick={() =>
+              toast.success("Whatever you were doing was successful")
+            }
+          >
+            success
+          </button>
+          <button
+            onClick={() =>
+              toast.warn("Whatever you were doing was kinda successful")
+            }
+          >
+            warning
+          </button>
+          <button
+            onClick={() => toast.error("Whatever you were doing failed lol")}
+          >
+            error
+          </button>
+        </div>
+      </div>
+      <div>
+        <h3>Toasts with logging</h3>
+        <button
+          onClick={() =>
+            toast.info("Oh btw here's some info on what you were doing", {
+              log: true,
+            })
+          }
+        >
+          info
+        </button>
+        <button
+          onClick={() =>
+            toast.success("Whatever you were doing was successful", {
+              log: true,
+            })
+          }
+        >
+          success
+        </button>
+        <button
+          onClick={() =>
+            toast.warn("Whatever you were doing was kinda successful", {
+              log: true,
+            })
+          }
+        >
+          warning
+        </button>
+        <button
+          onClick={() =>
+            toast.error("Whatever you were doing failed lol", { log: true })
+          }
+        >
+          error
+        </button>
+      </div>
+      <div>
+        <h2>Client Side Error Handling</h2>
+        <button
+          onClick={() => {
+            setIsClientSideError(true);
+          }}
+        >
+          Trigger a client side error
+        </button>
+      </div>
+      <div>
+        <h2>Logging</h2>
+        <button onClick={() => logger.info("Info log")}>info</button>
+        <button onClick={() => logger.debug("Debug log")}>debug</button>
+        <button onClick={() => logger.warn("Warning log")}>warning</button>
+        <button onClick={() => logger.error("Error log")}>error</button>
+      </div>
     </>
   );
 };

--- a/packages/frontend-v2/pages/index.tsx
+++ b/packages/frontend-v2/pages/index.tsx
@@ -2,13 +2,16 @@ import "react-toastify/dist/ReactToastify.min.css";
 import type { NextPage } from "next";
 import { toast, logger } from "../utils";
 import { useState } from "react";
-import { ClientSideError } from "../components/Error/ClientSideError";
+
+const Bomb: React.FC = () => {
+  throw Error("BOOOOM!");
+};
 
 const Home: NextPage = () => {
   const [isClientSideError, setIsClientSideError] = useState(false);
 
   if (isClientSideError) {
-    return <ClientSideError />;
+    return <Bomb />;
   }
 
   return (

--- a/packages/frontend-v2/utils/index.ts
+++ b/packages/frontend-v2/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./logger";
+export * from "./toast";

--- a/packages/frontend-v2/utils/logger.ts
+++ b/packages/frontend-v2/utils/logger.ts
@@ -1,0 +1,16 @@
+type LogType = "info" | "debug" | "warn" | "error";
+
+/**
+ * A logger utilty that encapsulates all logging logic. This will eventually have logic that
+ * handles production logging using tools like sentry.
+ */
+const log = (type: LogType, ...messages: unknown[]) => {
+  console[type](...messages);
+};
+
+export const logger = {
+  info: (...messages: unknown[]) => log("info", ...messages),
+  debug: (...messages: unknown[]) => log("debug", ...messages),
+  warn: (...messages: unknown[]) => log("warn", ...messages),
+  error: (...messages: unknown[]) => log("error", ...messages),
+};

--- a/packages/frontend-v2/utils/toast.ts
+++ b/packages/frontend-v2/utils/toast.ts
@@ -1,0 +1,33 @@
+import { toast as toastify } from "react-toastify";
+import { logger } from "./logger";
+
+type Options = {
+  log: boolean;
+};
+
+const successToast = (message: string, options?: Options) => {
+  options?.log && logger.debug(message);
+  toastify.success(message);
+};
+
+const warningToast = (message: string, options?: Options) => {
+  options?.log && logger.warn(message);
+  toastify.warning(message);
+};
+
+const errorToast = (message: string, options?: Options) => {
+  options?.log && logger.error(message);
+  toastify.error(message);
+};
+
+const infoToast = (message: string, options?: Options) => {
+  options?.log && logger.info(message);
+  toastify.info(message);
+};
+
+export const toast = {
+  success: successToast,
+  info: infoToast,
+  warn: warningToast,
+  error: errorToast,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,6 +2163,8 @@ __metadata:
     next: 12.1.4
     react: 18.0.0
     react-dom: 18.0.0
+    react-error-boundary: ^3.1.4
+    react-toastify: ^8.2.0
     typescript: 4.6.3
   languageName: unknown
   linkType: soft
@@ -6926,7 +6928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.0.4":
+"clsx@npm:^1.0.4, clsx@npm:^1.1.1":
   version: 1.1.1
   resolution: "clsx@npm:1.1.1"
   checksum: ff052650329773b9b245177305fc4c4dc3129f7b2be84af4f58dc5defa99538c61d4207be7419405a5f8f3d92007c954f4daba5a7b74e563d5de71c28c830063
@@ -17833,6 +17835,18 @@ __metadata:
     react: ^16.8.0 || ^17.0.0
     react-dom: ^16.8.0 || ^17.0.0
   checksum: 138b9c79c10313d513a40a8a5e6bc5c38e08f88208eeefd8a3f3da2eeecc954431a864d09ba76294456d8d15067526deb3ce76f1bec6d55fff17cc5a3df02a99
+  languageName: node
+  linkType: hard
+
+"react-toastify@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "react-toastify@npm:8.2.0"
+  dependencies:
+    clsx: ^1.1.1
+  peerDependencies:
+    react: ">=16"
+    react-dom: ">=16"
+  checksum: 670f1176fb9fd247c7ce0cad22e72578cbfa356dd1920a810ec4aa19faa4dab16db9efbdaaf761bdd368c4fad5c3d7f15568d5328b7b3c8699539064e88fcd4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Basic error handling(toasts for api errors, error boundary for client side) and logging.

- Added a logger utility that simply wraps console.log functionality. As our application matures, the logger can be made more sophisticated.
- Added a toast utility to display toasts using react-toastify. Currently a simple wrapper over react-toastify but the logic will mature as needed + we can easily migrate to another library/update the toast logic across the application.
- Added an ErrorBoundary that renders a very basic error page for now. Once, material UI and styled components are configured, the error page will be styled.

Closes [Error Handling](https://trello.com/c/QFjxMXRJ/430-error-handling)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This requires a run of `yarn install`

# How Has This Been Tested?

Buttons on the landing page to trigger all of the functionality added. Click on the buttons to view the toasts, logs in the console, or trigger a client side error that the Error Boundary catches

Note: `logger.debug` logs are not visible in the console by default. To view them you'll have to select the "verbose" option as shown below.

<img width="559" alt="Screen Shot 2022-04-12 at 5 19 07 PM" src="https://user-images.githubusercontent.com/30478978/163056410-d09493d2-2bda-4363-8cd2-a85300c51c5b.png">

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
