### PR TITLE
Fix CI Build

### DIFF
--- a/packages/scrapers-v2/tsconfig.json
+++ b/packages/scrapers-v2/tsconfig.json
@@ -16,7 +16,9 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "strictPropertyInitialization": false,
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
# Description

After https://github.com/sandboxnu/graduatenu/pull/413 was merged, the CI build failed because scrapers-v2's tsconfig is missing some options. Since we are using decorators in `dto-types`, we need to add `experimentalDecorators` to the config (more info see [here](https://www.typescriptlang.org/docs/handbook/decorators.html)). Additionally, we also initialize without having constructors in `dto-types`, so we also need an option for `strictPropertyInitialization` (see [here](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization)). 

Though I am not sure why CI build wasn't catching it before in the branch... unless the dto stuff was merged after. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

CI passing

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
