### PR TITLE
Updates the Backend to Support Onboarding Flow

### DIFF
--- a/packages/api-v2/src/auth/auth.controller.ts
+++ b/packages/api-v2/src/auth/auth.controller.ts
@@ -12,7 +12,7 @@ import { AuthService } from "./auth.service";
 import {
   GetStudentResponse,
   LoginStudentDto,
-  CreateStudentDto,
+  SignUpDto,
 } from "../../../common";
 import { Response } from "express";
 
@@ -23,7 +23,7 @@ export class AuthController {
   @Post("register")
   public async register(
     @Res({ passthrough: true }) response: Response,
-    @Body() createStudentDto: CreateStudentDto
+    @Body() createStudentDto: SignUpDto
   ): Promise<GetStudentResponse> {
     const student = await this.authService.register(createStudentDto);
     const { accessToken, ...studentInfo } = student;

--- a/packages/api-v2/src/auth/auth.service.ts
+++ b/packages/api-v2/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { Student } from "src/student/entities/student.entity";
 import { StudentService } from "src/student/student.service";
-import { LoginStudentDto, CreateStudentDto } from "../../../common";
+import { LoginStudentDto, SignUpDto } from "../../../common";
 import { JwtPayload } from "./interfaces/jwt-payload";
 import * as bcrypt from "bcrypt";
 
@@ -19,7 +19,7 @@ export class AuthService {
   /**
    * Registers a new student in the db and logs the student in.
    */
-  async register(createStudentDto: CreateStudentDto): Promise<Student> {
+  async register(createStudentDto: SignUpDto): Promise<Student> {
     // create a new student
     const newStudent = await this.studentService.create(createStudentDto);
 

--- a/packages/api-v2/src/student/entities/student.entity.ts
+++ b/packages/api-v2/src/student/entities/student.entity.ts
@@ -1,11 +1,11 @@
 import {
-  Entity,
-  Column,
-  PrimaryGeneratedColumn,
   BeforeInsert,
+  Column,
   CreateDateColumn,
-  UpdateDateColumn,
+  Entity,
   OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from "typeorm";
 import * as bcrypt from "bcrypt";
 import { Exclude } from "class-transformer";
@@ -20,8 +20,11 @@ export class Student {
   @Column({ nullable: true })
   nuid: string;
 
-  @Column()
+  @Column({ nullable: true })
   fullName: string;
+
+  @Column({ default: false })
+  isOnboarded: boolean;
 
   @Column({ unique: true })
   email: string;

--- a/packages/api-v2/src/student/student.controller.ts
+++ b/packages/api-v2/src/student/student.controller.ts
@@ -73,7 +73,7 @@ export class StudentController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Patch("onboard")
+  @Patch("me/onboard")
   async onBoard(
     @Req() req: AuthenticatedRequest,
     @Body() updateStudentDto: OnboardStudentDto

--- a/packages/api-v2/src/student/student.controller.ts
+++ b/packages/api-v2/src/student/student.controller.ts
@@ -1,28 +1,29 @@
 import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-  ParseUUIDPipe,
   BadRequestException,
-  UseGuards,
-  Req,
-  Query,
-  ParseBoolPipe,
+  Body,
+  Controller,
   DefaultValuePipe,
+  Delete,
+  Get,
+  Param,
+  ParseBoolPipe,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
 } from "@nestjs/common";
 import { StudentService } from "./student.service";
 import { JwtAuthGuard } from "src/guards/jwt-auth.guard";
 import { DevRouteGuard } from "src/guards/dev-route.guard";
 import { AuthenticatedRequest } from "src/auth/interfaces/authenticated-request";
 import {
-  GetStudentResponse,
-  UpdateStudentResponse,
   CreateStudentDto,
+  GetStudentResponse,
+  OnboardStudentDto,
   UpdateStudentDto,
+  UpdateStudentResponse,
 } from "../../../common";
 
 @Controller("students")
@@ -56,6 +57,32 @@ export class StudentController {
     const updateResult = await this.studentService.update(
       uuid,
       updateStudentDto
+    );
+
+    if (!updateResult) {
+      throw new BadRequestException();
+    }
+
+    const student = await this.studentService.findByUuid(uuid, true);
+
+    if (!student) {
+      throw new BadRequestException();
+    }
+
+    return student;
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch("onboard")
+  async onBoard(
+    @Req() req: AuthenticatedRequest,
+    @Body() updateStudentDto: OnboardStudentDto
+  ): Promise<UpdateStudentResponse> {
+    const uuid = req.user.uuid;
+    const updateResult = await this.studentService.update(
+      uuid,
+
+      { ...updateStudentDto, isOnboarded: true }
     );
 
     if (!updateResult) {

--- a/packages/api-v2/src/student/student.controller.ts
+++ b/packages/api-v2/src/student/student.controller.ts
@@ -79,11 +79,10 @@ export class StudentController {
     @Body() updateStudentDto: OnboardStudentDto
   ): Promise<UpdateStudentResponse> {
     const uuid = req.user.uuid;
-    const updateResult = await this.studentService.update(
-      uuid,
-
-      { ...updateStudentDto, isOnboarded: true }
-    );
+    const updateResult = await this.studentService.update(uuid, {
+      ...updateStudentDto,
+      isOnboarded: true,
+    });
 
     if (!updateResult) {
       throw new BadRequestException();

--- a/packages/api-v2/src/student/student.controller.ts
+++ b/packages/api-v2/src/student/student.controller.ts
@@ -5,6 +5,7 @@ import {
   DefaultValuePipe,
   Delete,
   Get,
+  InternalServerErrorException,
   Param,
   ParseBoolPipe,
   ParseUUIDPipe,
@@ -19,11 +20,11 @@ import { JwtAuthGuard } from "src/guards/jwt-auth.guard";
 import { DevRouteGuard } from "src/guards/dev-route.guard";
 import { AuthenticatedRequest } from "src/auth/interfaces/authenticated-request";
 import {
-  CreateStudentDto,
+  SignUpDto,
   GetStudentResponse,
   OnboardStudentDto,
-  UpdateStudentDto,
   UpdateStudentResponse,
+  UpdateStudentDto,
 } from "../../../common";
 
 @Controller("students")
@@ -76,22 +77,22 @@ export class StudentController {
   @Patch("me/onboard")
   async onBoard(
     @Req() req: AuthenticatedRequest,
-    @Body() updateStudentDto: OnboardStudentDto
+    @Body() onboardStudentDto: OnboardStudentDto
   ): Promise<UpdateStudentResponse> {
     const uuid = req.user.uuid;
     const updateResult = await this.studentService.update(uuid, {
-      ...updateStudentDto,
+      ...onboardStudentDto,
       isOnboarded: true,
     });
 
     if (!updateResult) {
-      throw new BadRequestException();
+      throw new InternalServerErrorException();
     }
 
     const student = await this.studentService.findByUuid(uuid, true);
 
     if (!student) {
-      throw new BadRequestException();
+      throw new InternalServerErrorException();
     }
 
     return student;
@@ -111,7 +112,7 @@ export class StudentController {
   @UseGuards(DevRouteGuard)
   @Post()
   async create(
-    @Body() createStudentDto: CreateStudentDto
+    @Body() createStudentDto: SignUpDto
   ): Promise<GetStudentResponse> {
     const student = await this.studentService.create(createStudentDto);
 
@@ -152,7 +153,7 @@ export class StudentController {
   @Patch(":uuid")
   async update(
     @Param("uuid", new ParseUUIDPipe()) uuid: string,
-    @Body() updateStudentDto: UpdateStudentDto
+    @Body() updateStudentDto: SignUpDto
   ): Promise<UpdateStudentResponse> {
     const updateResult = await this.studentService.update(
       uuid,

--- a/packages/api-v2/src/student/student.service.ts
+++ b/packages/api-v2/src/student/student.service.ts
@@ -6,7 +6,7 @@ import {
   Repository,
   UpdateResult,
 } from "typeorm";
-import { CreateStudentDto, UpdateStudentDto } from "../../../common";
+import { CreateStudentDto } from "../../../common";
 import { Student } from "./entities/student.entity";
 
 @Injectable()
@@ -71,7 +71,7 @@ export class StudentService {
 
   async update(
     uuid: string,
-    updateStudentDto: UpdateStudentDto
+    updateStudentDto: Partial<Student>
   ): Promise<UpdateResult> {
     const updateResult = await this.studentRepository.update(
       uuid,

--- a/packages/api-v2/src/student/student.service.ts
+++ b/packages/api-v2/src/student/student.service.ts
@@ -6,9 +6,9 @@ import {
   Repository,
   UpdateResult,
 } from "typeorm";
-import { CreateStudentDto } from "../../../common";
+import { SignUpDto } from "../../../common";
 import { Student } from "./entities/student.entity";
-
+import { UpdateStudentDto } from '../../../common/src/dto-types';
 @Injectable()
 export class StudentService {
   constructor(
@@ -16,7 +16,7 @@ export class StudentService {
     private studentRepository: Repository<Student>
   ) {}
 
-  async create(createStudentDto: CreateStudentDto): Promise<Student> {
+  async create(createStudentDto: SignUpDto): Promise<Student> {
     // make sure the user doesn't already exists
     const { email } = createStudentDto;
     const userInDb = await this.studentRepository.findOne({ where: { email } });
@@ -71,7 +71,7 @@ export class StudentService {
 
   async update(
     uuid: string,
-    updateStudentDto: Partial<Student>
+    updateStudentDto: UpdateStudentDto
   ): Promise<UpdateResult> {
     const updateResult = await this.studentRepository.update(
       uuid,

--- a/packages/common/src/dto-types.ts
+++ b/packages/common/src/dto-types.ts
@@ -77,61 +77,12 @@ export class UpdatePlanDto {
 
 export class CreateStudentDto {
   @IsNotEmpty()
-  @IsString()
-  fullName: string;
-
-  @IsString()
-  nuid: string;
-
-  @IsNotEmpty()
   @IsEmail()
   email: string;
 
   @IsNotEmpty()
   @IsString()
   password: string;
-
-  @IsOptional()
-  @IsInt()
-  @Min(1898) // the year NEU was established
-  @Max(3000) // will GraduateNU last beyond year 3000?!
-  academicYear?: number;
-
-  @IsOptional()
-  @IsInt()
-  @Min(1898)
-  @Max(3000)
-  graduateYear?: number;
-
-  @IsOptional()
-  @IsInt()
-  @Min(1898)
-  @Max(3000)
-  catalogYear?: number;
-
-  @IsOptional()
-  @IsString()
-  major?: string;
-
-  @IsOptional()
-  @IsString()
-  coopCycle?: string;
-
-  @IsOptional()
-  @IsObject()
-  coursesCompleted?: ScheduleCourse[];
-
-  @IsOptional()
-  @IsObject()
-  coursesTransfered?: ScheduleCourse[];
-
-  @IsOptional()
-  @IsInt()
-  primaryPlanId?: number;
-
-  @IsOptional()
-  @IsString()
-  concentration?: string;
 }
 
 export class UpdateStudentDto {
@@ -195,6 +146,48 @@ export class UpdateStudentDto {
   @IsOptional()
   @IsString()
   concentration?: string;
+}
+
+export class OnboardStudentDto {
+  @IsNotEmpty()
+  @IsString()
+  fullName: string;
+
+  @IsString()
+  nuid: string;
+
+  @IsInt()
+  @Min(1898) // the year NEU was established
+  @Max(3000) // will GraduateNU last beyond year 3000!
+  academicYear: number;
+
+  @IsInt()
+  @Min(1898)
+  @Max(3000)
+  graduateYear: number;
+
+  @IsInt()
+  @Min(1898)
+  @Max(3000)
+  catalogYear: number;
+
+  @IsString()
+  major: string;
+
+  @IsString()
+  coopCycle: string;
+
+  @IsObject()
+  coursesCompleted: ScheduleCourse[];
+
+  @IsObject()
+  coursesTransfered: ScheduleCourse[];
+
+  @IsInt()
+  primaryPlanId: number;
+
+  @IsString()
+  concentration: string;
 }
 
 export class LoginStudentDto {

--- a/packages/common/src/dto-types.ts
+++ b/packages/common/src/dto-types.ts
@@ -1,5 +1,6 @@
 import {
   IsArray,
+  IsBoolean,
   IsEmail,
   IsInt,
   IsNotEmpty,
@@ -75,7 +76,7 @@ export class UpdatePlanDto {
   warnings?: IWarning[];
 }
 
-export class CreateStudentDto {
+export class SignUpDto {
   @IsNotEmpty()
   @IsEmail()
   email: string;
@@ -146,6 +147,10 @@ export class UpdateStudentDto {
   @IsOptional()
   @IsString()
   concentration?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isOnboarded?: boolean;
 }
 
 export class OnboardStudentDto {

--- a/packages/common/src/response-types.ts
+++ b/packages/common/src/response-types.ts
@@ -20,6 +20,7 @@ export class UpdatePlanResponse extends PlanModel {}
 export class StudentModel {
   uuid: string;
   nuid: string;
+  isOnboarded: boolean;
   fullName: string;
   email: string;
   academicYear: number | undefined;


### PR DESCRIPTION
# Description

This PR is an update to the current `api-v2` backend where it now follows through with the Onboarding and Signup flow discussions held during component design. In more specific the implemented flow is as follows:

User signs up 
-> Information saved in backend, with all fields apart from `email`, `password`, and `uuid` set to null
-> Client side, user is redirected to onboarding
-> PATCH request to update the user after onboarding by sending a request to `/api/students/me/onboard`
-> Backend route requires for all fields to be present, then will update the user in db accordingly as well as set `isOnboarded` field of the user to be true

This implementation can be further looked at [here](https://www.notion.so/sandboxnu/Signup-Login-Design-dce4ba0d1c9f4eb3920490b9a43e1743).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run the appropriate calls to the backend to test that:
1. Registration of a user only populates `email` and `password`, other fields are null and `isOnboarded` is set to `false`.
2. Perform a PATCH request to the onboard route, and ensure that the user's fields are now all populated, and `isOnboarded` is set to `true`

The POSTMAN collection for this can be found [here](https://github.com/sandboxnu/graduatenu/files/8988462/GraduateNU-APIv2.json.zip).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] My changes generate no new warnings
