### PR TITLE
Make husky work for yarn2

### DIFF
--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env sh
 
 # taken from https://typicode.github.io/husky/#/?id=yarn-on-windows
 

--- a/.husky/common.sh
+++ b/.husky/common.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# taken from https://typicode.github.io/husky/#/?id=yarn-on-windows
+
+command_exists () {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Workaround for Windows 10, Git Bash and Yarn
+if command_exists winpty && test -t 1; then
+  exec < /dev/tty
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+. "$(dirname -- "$0")/common.sh"
+
+yarn pretty-quick --staged

--- a/package.json
+++ b/package.json
@@ -49,10 +49,5 @@
     "pretty-quick": "^3.1.3",
     "typescript": "^4.6.2"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged"
-    }
-  },
   "packageManager": "yarn@3.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint packages/ --ext .ts,.tsx .",
     "tsc": "yarn workspaces foreach -v --exclude . run tsc",
     "g:babel": "cd $INIT_CWD && babel",
-    "g:cross-env": "cd $INIT_CWD && cross-env"
+    "g:cross-env": "cd $INIT_CWD && cross-env",
+    "postinstall": "husky install"
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.17.8",
@@ -42,7 +43,7 @@
     "eslint-plugin-no-only-tests": "^2.6.0",
     "express": "^4.17.3",
     "http-proxy-middleware": "^2.0.3",
-    "husky": "^7.0.4",
+    "husky": "^8.0.0",
     "prettier": "^2.5.1",
     "prettier-plugin-jsdoc": "^0.3.38",
     "pretty-quick": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9855,7 +9855,7 @@ __metadata:
     eslint-plugin-no-only-tests: ^2.6.0
     express: ^4.17.3
     http-proxy-middleware: ^2.0.3
-    husky: ^7.0.4
+    husky: ^8.0.0
     prettier: ^2.5.1
     prettier-plugin-jsdoc: ^0.3.38
     pretty-quick: ^3.1.3
@@ -10248,6 +10248,15 @@ __metadata:
   bin:
     husky: lib/bin.js
   checksum: c6ec4af63da2c9522da8674a20ad9b48362cc92704896cc8a58c6a2a39d797feb2b806f93fbd83a6d653fbdceb2c3b6e0b602c6b2e8565206ffc2882ef7db9e9
+  languageName: node
+  linkType: hard
+
+"husky@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "husky@npm:8.0.1"
+  bin:
+    husky: lib/bin.js
+  checksum: 943a73a13d0201318fd30e83d299bb81d866bd245b69e6277804c3b462638dc1921694cb94c2b8c920a4a187060f7d6058d3365152865406352e934c5fff70dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

when we upgraded to yarn2, husky stopped working. this PR fixes that.

to fix, i followed the [automatic install instructions](https://typicode.github.io/husky/#/?id=automatic-recommended) for yarn2, additionally following the [yarn on windows](https://typicode.github.io/husky/#/?id=yarn-on-windows) fix for git bash.

the new way of writing hooks, it seems, is by running `yarn husky add .husky/<name> '<command>'`, which writes to a file of the specified name in the `.husky` directory.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This requires a run of `yarn install`

# How Has This Been Tested?

1. `yarn install`
2. edit a *.ts file to have incorrect formatting
3. `git add .` and `git commit`
4. `git diff HEAD~1`
5. verify that the formatting was fixed in the commit (by pretty-quick)

it would be great if someone could test out the changes on windows with git bash, however (since i don't have windows)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
