### PR TITLE
Fix JWT PR Bug

### DIFF
--- a/packages/api-v2/src/auth/auth.controller.ts
+++ b/packages/api-v2/src/auth/auth.controller.ts
@@ -26,11 +26,12 @@ export class AuthController {
     @Body() createStudentDto: SignUpDto
   ): Promise<GetStudentResponse> {
     const student = await this.authService.register(createStudentDto);
-    const { accessToken, ...studentInfo } = student;
 
     if (!student) {
       throw new BadRequestException();
     }
+
+    const { accessToken } = student;
 
     const isSecure = process.env.NODE_ENV !== "development";
     // Store JWT token in a cookie
@@ -40,7 +41,7 @@ export class AuthController {
       secure: isSecure,
     });
 
-    return studentInfo;
+    return student;
   }
 
   @Post("login")
@@ -49,11 +50,12 @@ export class AuthController {
     @Body() loginUserDto: LoginStudentDto
   ): Promise<GetStudentResponse> {
     const student = await this.authService.login(loginUserDto);
-    const { accessToken, ...studentInfo } = student;
 
     if (!student) {
       throw new UnauthorizedException();
     }
+
+    const { accessToken } = student;
 
     const isSecure = process.env.NODE_ENV !== "development";
     // Store JWT token in a cookie
@@ -62,7 +64,7 @@ export class AuthController {
       sameSite: "strict",
       secure: isSecure,
     });
-    return studentInfo;
+    return student;
   }
 
   @Get("logout")

--- a/packages/api-v2/src/student/entities/student.entity.ts
+++ b/packages/api-v2/src/student/entities/student.entity.ts
@@ -69,7 +69,8 @@ export class Student {
   @UpdateDateColumn({ default: () => "NOW()" })
   updatedAt: Date;
 
-  // attached to the student object when the student logs in
+  @Exclude()
+  // attached to the student object to be stored as a cookie only
   accessToken?: string;
 
   @BeforeInsert()


### PR DESCRIPTION
# Description

This PR addresses two bugs from the JWT PR oops. 
1. One was brought up by @BrandonLim8890 that the password field was being returned after registering/logging. `Exclude` decorator is being ignored when destructuring a student object. Solution: add `Exclude` to accessToken and return the student object.
2. When there is no accessToken (when email cannot be found or wrong pw), it returns 500 instead of 401. Solution: reordered destructuring and checking unauthorized.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

## Test A

No pw or accessToken returned
![Screen Shot 2022-07-22 at 17 53 33](https://user-images.githubusercontent.com/45154128/180576056-ec694aa6-4b09-4374-a9a8-ac8e48f6d0c4.png)

![Screen Shot 2022-07-22 at 17 53 29](https://user-images.githubusercontent.com/45154128/180576054-1d6b1efc-5825-4064-9807-2bb3c99e766a.png)

## Test B

Try it [here](https://www.getpostman.com/collections/46cd58bffd04d405ea47)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
