### PR TITLE
Fix bug in own-plan guard caused by logging PR

### DIFF
--- a/packages/api-v2/graduate-logger.ts
+++ b/packages/api-v2/graduate-logger.ts
@@ -1,11 +1,11 @@
 import { ConsoleLogger, LogLevel } from "@nestjs/common";
 import { deepFilter } from "src/utils";
 
-const BLACKLIST = ["password"];
+const DENYLIST = ["password"];
 
 export class GraduateLogger extends ConsoleLogger {
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {
-    message = deepFilter(message, BLACKLIST);
+    message = deepFilter(message, DENYLIST);
     return super.stringifyMessage(message, logLevel);
   }
 }

--- a/packages/api-v2/src/guards/own-plan.guard.ts
+++ b/packages/api-v2/src/guards/own-plan.guard.ts
@@ -54,5 +54,7 @@ export class OwnPlanGuard implements CanActivate {
         formatServiceCtx("OwnPlanGuard", "canActivate")
       );
     }
+
+    return res;
   }
 }

--- a/packages/api-v2/src/interceptors/logging.interceptor.ts
+++ b/packages/api-v2/src/interceptors/logging.interceptor.ts
@@ -75,12 +75,7 @@ export class LoggingInterceptor implements NestInterceptor {
     const { statusCode } = res;
     const ctx = this.formatCtx(LogType.Response, method, url, statusCode);
 
-    this.logger.log(
-      {
-        body,
-      },
-      ctx
-    );
+    this.logger.log({ body }, ctx);
   }
 
   /**


### PR DESCRIPTION
# Description

This fixes a bug introduced through the logging pr in own-plan guard that prevented students to access their own plan. Also addresses some nits pointed out by @bugsalexander 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Postman.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
