### PR TITLE
Frontend V2 - Toggle Years In A Plan

### DIFF
--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Grid, GridItem } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 import { PlanModel, ScheduleYear2 } from "@graduate/common";
 import { useState } from "react";
 import { ScheduleYear } from "./ScheduleYear";
@@ -32,7 +32,7 @@ export const Plan: React.FC<PlanProps> = ({ plan }) => {
 
   return (
     <Flex flexDirection="column" rowGap="4xs">
-      {plan.schedule.years.map((scheduleYear, idx) => {
+      {plan.schedule.years.map((scheduleYear) => {
         const isExpanded = expandedYears.has(scheduleYear.year);
 
         return (

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -1,5 +1,6 @@
-import { Grid, GridItem } from "@chakra-ui/react";
-import { PlanModel } from "@graduate/common";
+import { Box, Flex, Grid, GridItem } from "@chakra-ui/react";
+import { PlanModel, ScheduleYear2 } from "@graduate/common";
+import { useState } from "react";
 import { ScheduleYear } from "./ScheduleYear";
 
 interface PlanProps {
@@ -7,18 +8,48 @@ interface PlanProps {
 }
 
 export const Plan: React.FC<PlanProps> = ({ plan }) => {
-  const numYears = plan.schedule.years.length;
+  const [expandedYears, setExpandedYears] = useState<Set<number>>(new Set());
+
+  const toggleExpanded = (year: ScheduleYear2<string>) => {
+    if (expandedYears.has(year.year)) {
+      removeFromExpandedYears(year);
+    } else {
+      addToExpandedYears(year);
+    }
+  };
+
+  const removeFromExpandedYears = (year: ScheduleYear2<string>) => {
+    const updatedSet = new Set(expandedYears);
+    updatedSet.delete(year.year);
+    setExpandedYears(updatedSet);
+  };
+
+  const addToExpandedYears = (year: ScheduleYear2<string>) => {
+    const updatedSet = new Set(expandedYears);
+    updatedSet.add(year.year);
+    setExpandedYears(updatedSet);
+  };
+
   return (
-    <Grid templateRows={`repeat(${numYears}, 1fr)`}>
-      {plan.schedule.years.map((scheduleYear, idx) => (
-        <GridItem
-          key={scheduleYear.year}
-          borderX="1px"
-          borderBottom={idx === numYears - 1 ? "1px" : undefined}
-        >
-          <ScheduleYear scheduleYear={scheduleYear} />
-        </GridItem>
-      ))}
-    </Grid>
+    <Flex flexDirection="column" rowGap="4xs">
+      {plan.schedule.years.map((scheduleYear, idx) => {
+        const isExpanded = expandedYears.has(scheduleYear.year);
+
+        return (
+          <Box
+            key={scheduleYear.year}
+            borderX={isExpanded ? "1px" : undefined}
+            borderBottom={isExpanded ? "1px" : undefined}
+            minHeight={isExpanded ? "300px" : undefined}
+          >
+            <ScheduleYear
+              scheduleYear={scheduleYear}
+              isExpanded={isExpanded}
+              toggleExpanded={() => toggleExpanded(scheduleYear)}
+            />
+          </Box>
+        );
+      })}
+    </Flex>
   );
 };

--- a/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
@@ -22,7 +22,7 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
       backgroundColor={isOver ? "neutral.300" : undefined}
       px="sm"
       pt="2xs"
-      pb="sm"
+      pb="xl"
     >
       <ScheduleTermHeader
         season={scheduleTerm.season}

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -9,11 +9,20 @@ import {
 import { ScheduleYear2 } from "@graduate/common";
 import { ScheduleTerm } from "./ScheduleTerm";
 
-interface ScheduleYearProps {
+interface ToggleYearProps {
+  isExpanded: boolean;
+  toggleExpanded: () => void;
+}
+
+interface ScheduleYearProps extends ToggleYearProps {
   scheduleYear: ScheduleYear2<string>;
 }
 
-export const ScheduleYear: React.FC<ScheduleYearProps> = ({ scheduleYear }) => {
+export const ScheduleYear: React.FC<ScheduleYearProps> = ({
+  scheduleYear,
+  isExpanded,
+  toggleExpanded,
+}) => {
   // sum all credits over all the courses over each semester
   const totalCreditsThisYear = [
     scheduleYear.fall,
@@ -33,47 +42,67 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({ scheduleYear }) => {
   }, 0);
 
   return (
-    <Flex flexDirection="column" height="100%">
+    <Flex flexDirection="column" height="100%" minHeight="inherit">
       <YearHeader
         year={scheduleYear}
         totalCreditsTaken={totalCreditsThisYear}
+        isExpanded={isExpanded}
+        toggleExpanded={toggleExpanded}
       />
-      <Grid templateColumns="repeat(4, 1fr)" flex={1}>
-        <ScheduleTerm scheduleTerm={scheduleYear.fall} />
-        <ScheduleTerm scheduleTerm={scheduleYear.spring} />
-        {/* TODO: support summer full term */}
-        <ScheduleTerm scheduleTerm={scheduleYear.summer1} />
-        <ScheduleTerm scheduleTerm={scheduleYear.summer2} isLastColumn />
-      </Grid>
+      {isExpanded && (
+        <Grid templateColumns="repeat(4, 1fr)" flex={1}>
+          <ScheduleTerm scheduleTerm={scheduleYear.fall} />
+          <ScheduleTerm scheduleTerm={scheduleYear.spring} />
+          {/* TODO: support summer full term */}
+          <ScheduleTerm scheduleTerm={scheduleYear.summer1} />
+          <ScheduleTerm scheduleTerm={scheduleYear.summer2} isLastColumn />
+        </Grid>
+      )}
     </Flex>
   );
 };
 
-interface YearHeaderProps {
+interface YearHeaderProps extends ToggleYearProps {
   year: ScheduleYear2<string>;
   totalCreditsTaken: number;
 }
 
-const YearHeader: React.FC<YearHeaderProps> = ({ year, totalCreditsTaken }) => {
+/** Displays the academic year, credits taken and hide/show button for the year. */
+const YearHeader: React.FC<YearHeaderProps> = ({
+  year,
+  totalCreditsTaken,
+  isExpanded,
+  toggleExpanded,
+}) => {
+  const backgroundColor = isExpanded
+    ? "primary.blue.dark"
+    : "primary.blue.light";
+
   return (
     <Grid templateColumns="repeat(12, 1fr)" alignItems="center">
-      <YearHeaderColumnContainer colSpan={1} justifyContent="center" mr="5xs">
+      <YearHeaderColumnContainer
+        colSpan={1}
+        justifyContent="center"
+        mr="5xs"
+        bg={`${backgroundColor}.main`}
+      >
         <Text fontWeight="bold" color="white">
           Year {year.year}
         </Text>
       </YearHeaderColumnContainer>
-      <YearHeaderColumnContainer colSpan={10} pl="md">
+      <YearHeaderColumnContainer
+        colSpan={10}
+        pl="md"
+        bg={`${backgroundColor}.main`}
+      >
         <Text color="white">{totalCreditsTaken} credits</Text>
       </YearHeaderColumnContainer>
-      <YearHeaderColumnContainer colSpan={1} bg="primary.blue.dark.900">
-        <Button
-          variant="unstyled"
-          width="100%"
-          textTransform="uppercase"
-          color="neutral.main"
-        >
-          hide
-        </Button>
+      <YearHeaderColumnContainer colSpan={1} bg={`${backgroundColor}.700`}>
+        <ToggleExpandedYearButton
+          backgroundColor={backgroundColor}
+          isExpanded={isExpanded}
+          toggleExpanded={toggleExpanded}
+        />
       </YearHeaderColumnContainer>
     </Grid>
   );
@@ -85,14 +114,32 @@ const YearHeaderColumnContainer: React.FC<GridItemProps> = ({
   ...rest
 }) => {
   return (
-    <GridItem
-      height="100%"
-      bg="primary.blue.dark.main"
-      display="flex"
-      alignItems="center"
-      {...rest}
-    >
+    <GridItem height="100%" display="flex" alignItems="center" {...rest}>
       {children}
     </GridItem>
+  );
+};
+
+interface ToggleExpandedYearButtonProps extends ToggleYearProps {
+  backgroundColor: string;
+}
+
+const ToggleExpandedYearButton: React.FC<ToggleExpandedYearButtonProps> = ({
+  backgroundColor,
+  isExpanded,
+  toggleExpanded,
+}) => {
+  return (
+    <Button
+      variant="unstyled"
+      width="100%"
+      textTransform="uppercase"
+      color="neutral.main"
+      onClick={toggleExpanded}
+      _hover={{ bg: `${backgroundColor}.900` }}
+      _active={{ bg: `${backgroundColor}.900` }}
+    >
+      {isExpanded ? "hide" : "show"}
+    </Button>
   );
 };

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -16,7 +16,7 @@ import {
 import { API } from "@graduate/api-client";
 import { PlanModel } from "@graduate/common";
 import { useRouter } from "next/router";
-import { Button, Grid, GridItem } from "@chakra-ui/react";
+import { Box, Button, Flex, Grid, GridItem } from "@chakra-ui/react";
 import { handleApiClientError } from "../utils/handleApiClientError";
 
 const HomePage: NextPage = () => {
@@ -107,15 +107,15 @@ const HomePage: NextPage = () => {
  */
 const PageLayout: React.FC = ({ children }) => {
   return (
-    <>
+    <Flex flexDirection="column" height="100vh">
       <Header />
-      <Grid height="200px" templateColumns="repeat(4, 1fr)" gap="md">
-        <GridItem rowSpan={1} colSpan={1} bg="primary.blue.light.main" />
-        <GridItem rowSpan={1} colSpan={3} p="md">
+      <Grid flex={1} templateColumns="repeat(4, 1fr)" gap="md">
+        <GridItem colSpan={1} bg="primary.blue.light.main" />
+        <GridItem colSpan={3} p="md">
           {children}
         </GridItem>
       </Grid>
-    </>
+    </Flex>
   );
 };
 

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -16,7 +16,7 @@ import {
 import { API } from "@graduate/api-client";
 import { PlanModel } from "@graduate/common";
 import { useRouter } from "next/router";
-import { Box, Button, Flex, Grid, GridItem } from "@chakra-ui/react";
+import { Button, Flex, Grid, GridItem } from "@chakra-ui/react";
 import { handleApiClientError } from "../utils/handleApiClientError";
 
 const HomePage: NextPage = () => {


### PR DESCRIPTION
# Description

https://user-images.githubusercontent.com/30478978/186754360-421f74d7-2c0b-4f97-9b01-c0774719994f.mov

Reminder: This PR is "stacked" on top of v2-plan-styling. This diff will only show changes specific to toggling year expansion.

This PR adds support to toggle years in a plan.

An overview of all the functionality completed and remaining for the plan component(note, there may be more stuff remaining but this is what i can think of for now).

- [x] fetch plans and populate dnd ids
- [x] basic plan component with dnd and posting to API
- [x] styling: previous PR
- [x] **collapsing years: current PR**
- [ ] choosing which plan to display
- [ ] adding a course using the add course modal
- [ ] adding a Plan
- [ ] choosing primary plan
  - [ ] fix backend bug of allowing users to choose a primary plan that doesn't belong to this(massive security issue) 
- [ ] validation and errors
- [ ] add class validator decorators to schedule type so that we enforce at least some shape of the schedule when posting
- [ ] figure out how to show "preview" of course in the position it was when it is being dragged around
- [ ] batch/throttle plan updates

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually. Check video.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
