### PR TITLE
Frontend V2 - Switch Plans

### DIFF
--- a/packages/common/src/response-types.ts
+++ b/packages/common/src/response-types.ts
@@ -30,7 +30,7 @@ export class StudentModel<T> {
   coopCycle: string | undefined;
   coursesCompleted: ScheduleCourse[] | undefined;
   coursesTransfered: ScheduleCourse[] | undefined;
-  primaryPlanId: number | true;
+  primaryPlanId: number;
   plans: PlanModel<T>[];
   concentration: string | undefined;
   createdAt: Date;

--- a/packages/frontend-v2/components/Plan/PlanDropdown.tsx
+++ b/packages/frontend-v2/components/Plan/PlanDropdown.tsx
@@ -3,9 +3,9 @@ import { Select } from "@chakra-ui/react";
 import { PlanModel } from "@graduate/common";
 
 interface PlanDropdownProps {
-  setSelectedPlanId: Dispatch<SetStateAction<number | undefined>>;
+  setSelectedPlanId: Dispatch<SetStateAction<number | undefined | null>>;
   plans: PlanModel<string>[];
-  selectedPlanId?: number;
+  selectedPlanId: number | undefined | null;
 }
 export const PlanDropdown: React.FC<PlanDropdownProps> = ({
   setSelectedPlanId,
@@ -18,8 +18,14 @@ export const PlanDropdown: React.FC<PlanDropdownProps> = ({
       width="15%"
       mb="sm"
       borderRadius="0"
-      value={selectedPlanId}
+      value={selectedPlanId ? selectedPlanId : undefined}
       onChange={(e) => {
+        if (!e.target.value) {
+          // no plan is selected, indicated using null(different from undef which is the initial state)
+          setSelectedPlanId(null);
+          return;
+        }
+
         const selectedPlanId = parseInt(e.target.value);
         setSelectedPlanId(selectedPlanId);
       }}

--- a/packages/frontend-v2/components/Plan/PlanDropdown.tsx
+++ b/packages/frontend-v2/components/Plan/PlanDropdown.tsx
@@ -1,0 +1,34 @@
+import React, { Dispatch, SetStateAction } from "react";
+import { Select } from "@chakra-ui/react";
+import { PlanModel } from "@graduate/common";
+
+interface PlanDropdownProps {
+  setSelectedPlanId: Dispatch<SetStateAction<number | undefined>>;
+  plans: PlanModel<string>[];
+  selectedPlanId?: number;
+}
+export const PlanDropdown: React.FC<PlanDropdownProps> = ({
+  setSelectedPlanId,
+  plans,
+  selectedPlanId,
+}) => {
+  return (
+    <Select
+      placeholder="Select Plan"
+      width="15%"
+      mb="sm"
+      borderRadius="0"
+      value={selectedPlanId}
+      onChange={(e) => {
+        const selectedPlanId = parseInt(e.target.value);
+        setSelectedPlanId(selectedPlanId);
+      }}
+    >
+      {plans.map((plan) => (
+        <option value={plan.id} key={plan.id}>
+          {plan.name}
+        </option>
+      ))}
+    </Select>
+  );
+};

--- a/packages/frontend-v2/components/Plan/index.ts
+++ b/packages/frontend-v2/components/Plan/index.ts
@@ -1,1 +1,2 @@
 export * from "./Plan";
+export * from "./PlanDropdown";

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -30,8 +30,21 @@ const HomePage: NextPage = () => {
   const { error, student, mutateStudent } = useStudentWithPlans();
   const router = useRouter();
 
-  // keep track of the plan being displayed
-  const [selectedPlanId, setSelectedPlanId] = useState<number | undefined>();
+  /*
+   * Keep track of the plan being displayed, initially undef and later either the plan id or null.
+   * undef is used to indicate the initial state where the primary plan should be used, null is to define
+   * the state where no plan should be used.
+   */
+  const [selectedPlanId, setSelectedPlanId] = useState<
+    number | undefined | null
+  >();
+
+  useEffect(() => {
+    // once the student is fetched, set the selected plan id to the primary plan id
+    if (student && selectedPlanId === undefined) {
+      setSelectedPlanId(student.primaryPlanId);
+    }
+  }, [student, selectedPlanId, setSelectedPlanId]);
 
   // handle error state
   if (error) {
@@ -48,18 +61,6 @@ const HomePage: NextPage = () => {
   }
 
   const selectedPlan = student.plans.find((plan) => selectedPlanId === plan.id);
-
-  // use the primary plan if no plan is selected
-  if (!selectedPlan) {
-    const primaryPlan = student.plans.find(
-      (plan) => student.primaryPlanId === plan.id
-    );
-
-    // ensure a valid primary plan exists
-    if (primaryPlan) {
-      setSelectedPlanId(student.primaryPlanId);
-    }
-  }
 
   /**
    * When a course is dragged and dropped onto a semester
@@ -130,9 +131,7 @@ const HomePage: NextPage = () => {
       <DndContext onDragEnd={handleDragEnd}>
         <Flex flexDirection="column">
           <PlanDropdown
-            selectedPlanId={
-              selectedPlanId ? selectedPlanId : student.primaryPlanId
-            }
+            selectedPlanId={selectedPlanId}
             setSelectedPlanId={setSelectedPlanId}
             plans={student.plans}
           />

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -38,8 +38,7 @@ const HomePage: NextPage = () => {
     if (!student) {
       // if student doesn't exist then there is no plan to display
       setSelectedPlanId(undefined);
-    } else if (!selectedPlanId) {
-      // if student exists but there is no plan to display, then default to primary plan
+    } else {
       setSelectedPlanId(student.primaryPlanId);
     }
   }, [student, selectedPlanId]);

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -33,16 +33,6 @@ const HomePage: NextPage = () => {
   // keep track of the plan being displayed
   const [selectedPlanId, setSelectedPlanId] = useState<number | undefined>();
 
-  // set the primary plan to be the plan displayed initially
-  useEffect(() => {
-    if (!student) {
-      // if student doesn't exist then there is no plan to display
-      setSelectedPlanId(undefined);
-    } else {
-      setSelectedPlanId(student.primaryPlanId);
-    }
-  }, [student]);
-
   // handle error state
   if (error) {
     logger.error("HomePage", error);
@@ -58,6 +48,18 @@ const HomePage: NextPage = () => {
   }
 
   const selectedPlan = student.plans.find((plan) => selectedPlanId === plan.id);
+
+  // use the primary plan if no plan is selected
+  if (!selectedPlan) {
+    const primaryPlan = student.plans.find(
+      (plan) => student.primaryPlanId === plan.id
+    );
+
+    // ensure a valid primary plan exists
+    if (primaryPlan) {
+      setSelectedPlanId(student.primaryPlanId);
+    }
+  }
 
   /**
    * When a course is dragged and dropped onto a semester
@@ -128,7 +130,9 @@ const HomePage: NextPage = () => {
       <DndContext onDragEnd={handleDragEnd}>
         <Flex flexDirection="column">
           <PlanDropdown
-            selectedPlanId={selectedPlanId}
+            selectedPlanId={
+              selectedPlanId ? selectedPlanId : student.primaryPlanId
+            }
             setSelectedPlanId={setSelectedPlanId}
             plans={student.plans}
           />

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -41,7 +41,7 @@ const HomePage: NextPage = () => {
     } else {
       setSelectedPlanId(student.primaryPlanId);
     }
-  }, [student, selectedPlanId]);
+  }, [student]);
 
   // handle error state
   if (error) {


### PR DESCRIPTION
# Description

https://user-images.githubusercontent.com/30478978/186790661-a22e5571-ad69-45bf-bcd3-a1e6c8170b63.mov

Reminder: This PR is "stacked" on top of v2-plan-toggle-year. This diff will only show changes specific to switching plans.

Allows the user to switch between multiple plans. Displays primary plan if the user has one.

An overview of all the functionality completed and remaining for the plan component(note, there may be more stuff remaining but this is what i can think of for now).

- [x] fetch plans and populate dnd ids
- [x] basic plan component with dnd and posting to API
- [x] styling
- [x] collapsing years: previous PR
- [x] **choosing which plan to display** current PR
- [ ] adding a course using the add course modal
- [ ] adding a Plan
- [ ] choosing primary plan
  - [ ] fix backend bug of allowing users to choose a primary plan that doesn't belong to this(massive security issue) 
- [ ] validation and errors
- [ ] add class validator decorators to schedule type so that we enforce at least some shape of the schedule when posting
- [ ] figure out how to show "preview" of course in the position it was when it is being dragged around
- [ ] batch/throttle plan updates

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually. See video. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
