### PR TITLE
Frontend V2 - Handle Home Page Errors

### DIFF
--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -45,7 +45,17 @@ const HomePage: NextPage = () => {
     }
   }, [student, selectedPlanId, setSelectedPlanId]);
 
-  // handle error state
+  /**
+   * Handle errors from useStudentWithPlans.
+   *
+   * Unfortunately, error could be from useStudentWithPlans or from
+   * mutateStudent. But mutate student error is handled seperately by rolling
+   * back the update.
+   *
+   * To specifically handle useStudentWithPlans error we check if the student is
+   * not defined. Since if mutate student errors, student will still be defined
+   * since we rollback the student state on error.
+   */
   if (error && !student) {
     logger.error("HomePage", error);
     handleApiClientError(error, router);

--- a/packages/frontend-v2/utils/handleApiClientError.ts
+++ b/packages/frontend-v2/utils/handleApiClientError.ts
@@ -3,6 +3,11 @@ import { NextRouter } from "next/router";
 import { logger } from "./logger";
 import { toast } from "./toast";
 
+enum ErrorToastId {
+  UNAUTHORIZED = "unauthorized",
+  SERVER_ERROR = "server error",
+}
+
 /**
  * Handles the error returned by our API client.
  *
@@ -39,7 +44,9 @@ const handleAxiosError = (error: AxiosError, router: NextRouter) => {
     router.push("/login");
   } else if (statusCode === 403) {
     logger.debug("handleApiClientError", "Unauthorized", error);
-    toast.error("Sorry, you don't have valid permissions.");
+    toast.error("Sorry, you don't have valid permissions.", {
+      toastId: ErrorToastId.UNAUTHORIZED,
+    });
   } else {
     logger.debug(
       "handleApiClientError",
@@ -48,6 +55,8 @@ const handleAxiosError = (error: AxiosError, router: NextRouter) => {
     );
 
     // TODO: Add some sort of google form/email for a user to report this error
-    toast.error("Sorry, something went wrong on our end :(");
+    toast.error("Sorry, something went wrong on our end :(", {
+      toastId: ErrorToastId.SERVER_ERROR,
+    });
   }
 };

--- a/packages/frontend-v2/utils/toast.ts
+++ b/packages/frontend-v2/utils/toast.ts
@@ -2,27 +2,28 @@ import { toast as toastify } from "react-toastify";
 import { logger } from "./logger";
 
 type Options = {
-  log: boolean;
+  log?: boolean;
+  toastId?: string | number;
 };
 
 const successToast = (message: string, options?: Options) => {
   options?.log && logger.debug(message);
-  toastify.success(message);
+  toastify.success(message, { toastId: options?.toastId });
 };
 
 const warningToast = (message: string, options?: Options) => {
   options?.log && logger.warn(message);
-  toastify.warning(message);
+  toastify.warning(message, { toastId: options?.toastId });
 };
 
 const errorToast = (message: string, options?: Options) => {
   options?.log && logger.error(message);
-  toastify.error(message);
+  toastify.error(message, { toastId: options?.toastId });
 };
 
 const infoToast = (message: string, options?: Options) => {
   options?.log && logger.info(message);
-  toastify.info(message);
+  toastify.info(message, { toastId: options?.toastId });
 };
 
 export const toast = {


### PR DESCRIPTION
# Description

Reminder: This PR is "stacked" on top of v2-plan-switch-plan. This diff will only show changes specific to handling home page errors.

https://user-images.githubusercontent.com/30478978/186956363-2f5aa1b1-2401-48a9-b868-60d4594768a0.mov

Ensure the home page handles errors from our backend currently. This involves 2 fixes:
- Toasts for a specific error type are only displayed once, no matter how many times useSWR tries refetching(we don't want a page full of toasts "something went wrong" while SWR keeps retrying, the user understand with one toast)

- Rollback on error when posting the updated plan fails. Weirdly i thought i had enabled this but apparently i didn't. 
An overview of all the functionality completed and remaining for the plan component(note, there may be more stuff remaining but this is what i can think of for now).

An overview of all the functionality completed and remaining for the plan component(note, there may be more stuff remaining but this is what i can think of for now).

- [x] fetch plans and populate dnd ids
- [x] basic plan component with dnd and posting to API
- [x] styling
- [x] collapsing years
- [x] choosing which plan to display: previous PR
- [x] **handle home page errors: current PR** 
- [ ] adding a course using the add course modal
- [ ] adding a Plan
- [ ] choosing primary plan
  - [ ] fix backend bug of allowing users to choose a primary plan that doesn't belong to this(massive security issue) 
- [ ] validation and errors
- [ ] add class validator decorators to schedule type so that we enforce at least some shape of the schedule when posting
- [ ] figure out how to show "preview" of course in the position it was when it is being dragged around
- [ ] batch/throttle plan updates

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually by throwing errors from the backend. Check video.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
