### PR TITLE
Documentation - Update Example Postman Queries

### DIFF
--- a/packages/common/test/assets/postman-api.json
+++ b/packages/common/test/assets/postman-api.json
@@ -1,9 +1,9 @@
 {
   "info": {
-    "_postman_id": "a983b98f-4803-4b21-989d-2594ac97fae1",
+    "_postman_id": "4d5090bc-f868-4ab5-b772-d6d8a8a4b5c7",
     "name": "GraduateNU",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "19576221"
+    "_exporter_id": "12208846"
   },
   "item": [
     {
@@ -59,7 +59,7 @@
           "variable": [
             {
               "key": "uuid",
-              "value": "3b130db1-f71b-4abe-ba7d-4b7fe63d1d8c"
+              "value": "88f1c807-cef5-4b5d-9800-0eac2024a169"
             }
           ]
         }
@@ -73,7 +73,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"email\":\"aryan1@gmail.com\",\n    \"password\":\"aryan1234\"\n}",
+          "raw": "{\n    \"email\":\"aryan101@gmail.com\",\n    \"password\":\"aryan1234\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -122,7 +122,7 @@
           "variable": [
             {
               "key": "uuid",
-              "value": "d641edde-63fd-4b97-a0e9-cfa0ce4c6f62"
+              "value": "e577d120-92ff-4001-ace3-a9a5cd916efe"
             }
           ]
         }
@@ -136,7 +136,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"fullName\":\"Aryan Shah\",\n    \"email\":\"aryan101@gmail.com\",\n    \"password\":\"aryan1234\",\n    \"academicYear\":2019,\n    \"graduateYear\":2023,\n    \"catalogYear\":2019,\n    \"major\":\"Computer Science\",\n    \"nuid\":\"000000000\"\n}",
+          "raw": "{\n    \"fullName\":\"Aryan Shah\",\n    \"email\":\"aryan101@gmail.com\",\n    \"password\":\"aryan1234\",\n    \"passwordConfirm\":\"aryan1234\",\n    \"academicYear\":2019,\n    \"graduateYear\":2023,\n    \"catalogYear\":2019,\n    \"major\":\"Computer Science\",\n    \"nuid\":\"000000000\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -237,7 +237,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"fullName\":\"Aryan Shah Updated\"\n}",
+          "raw": "{\n    \"primaryPlanId\": 1\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -262,7 +262,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"name\": \"Plan 1\",\n    \"major\": \"Computer Science\",\n    \"coopCycle\": \"Fall\",\n    \"concentration\": \"Software\",\n    \"catalogYear\": 2019,\n    \"courseWarnings\": [],\n    \"warnings\": [],\n    \"schedule\": {\n        \"years\": [2019, 2020, 2021, 2022],\n        \"yearMap\": {\n            \"2019\": {\n                \"year\": 2019,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            \"2020\": {\n                \"year\": 2020,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            \"2021\": {\n                \"year\": 2021,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            \"2022\": {\n                \"year\": 2022,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            }\n        }\n    }\n}",
+          "raw": "{\n    \"name\": \"New Plan\",\n    \"major\": \"Computer Science\",\n    \"coopCycle\": \"Fall\",\n    \"concentration\": \"Software\",\n    \"catalogYear\": 2019,\n    \"courseWarnings\": [],\n    \"warnings\": [],\n    \"schedule\": {\n        \"years\": [\n            {\n                \"year\": 2019,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2019,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            {\n                \"year\": 2020,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2020,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            {\n                \"year\": 2021,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2021,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            },\n            {\n                \"year\": 2022,\n                \"fall\": {\n                    \"season\": \"FL\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"spring\": {\n                    \"season\": \"SP\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer1\": {\n                    \"season\": \"S1\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"summer2\": {\n                    \"season\": \"S2\",\n                    \"year\": 2022,\n                    \"termId\": 1,\n                    \"status\": \"CLASSES\",\n                    \"classes\": []\n                },\n                \"isSummerFull\": false\n            }\n        ]\n    }\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -287,7 +287,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"schedule\": {\n        \"years\": [\n            2019,\n            2020,\n            2021,\n            2022,\n            2023\n        ]\n    }\n}",
+          "raw": "{\n    \"schedule\": {}\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -311,9 +311,22 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{API_URL}}/{{PLANS}}/2",
+          "raw": "{{API_URL}}/{{PLANS}}/1",
           "host": ["{{API_URL}}"],
-          "path": ["{{PLANS}}", "2"]
+          "path": ["{{PLANS}}", "1"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Delete Plan",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{API_URL}}/{{PLANS}}/1",
+          "host": ["{{API_URL}}"],
+          "path": ["{{PLANS}}", "1"]
         }
       },
       "response": []


### PR DESCRIPTION
This PR updates the example Postman queries provided to work with our API. 

**[Fix]:** Fixed the create the create plan query (POST /api/plans/). This was not working properly because it assumed the v1 plan type, and has now been updated to work with v2 plans.

**[Fix]:** Fixed the Register Student endpoint (POST /api/auth/register). This was not working properly because it needed the passwordConfirm field in the body. 

**[Added]:** Added a Delete Plan query to the options as it was available in our API, but not provided as an example query.



