### PR TITLE
Add Support To Edit An Existing Plan

### DIFF
--- a/packages/frontend-v2/components/Form/Input.tsx
+++ b/packages/frontend-v2/components/Form/Input.tsx
@@ -3,6 +3,7 @@ import {
   Input,
   FormErrorMessage,
   InputGroup,
+  FormLabel,
 } from "@chakra-ui/react";
 import { FieldError } from "react-hook-form";
 import { forwardRef } from "react";
@@ -17,7 +18,7 @@ interface InputProps {
 // eslint-disable-next-line react/display-name
 export const StringInput = forwardRef<HTMLInputElement, InputProps>(
   ({ error, ...rest }, ref) => (
-    <FormControl isInvalid={error != undefined} height='2xl'>
+    <FormControl isInvalid={error != undefined} height="2xl">
       <InputGroup>
         <Input
           {...rest}
@@ -27,7 +28,33 @@ export const StringInput = forwardRef<HTMLInputElement, InputProps>(
           errorBorderColor="red.300"
         />
       </InputGroup>
-      <FormErrorMessage mt='3xs'>{error?.message}</FormErrorMessage>
+      <FormErrorMessage mt="3xs">{error?.message}</FormErrorMessage>
     </FormControl>
   )
 );
+
+type PlanInputOwnProps = {
+  error?: FieldError;
+  label: string;
+};
+
+type PlanInputProps = PlanInputOwnProps & InputProps;
+
+export const PlanInput = forwardRef<HTMLInputElement, PlanInputProps>(
+  ({ error, label, ...rest }, ref) => (
+    <FormControl isInvalid={error != null}>
+      <FormLabel
+        color="primary.red.main"
+        size="md"
+        fontWeight="medium"
+        mb="2xs"
+      >
+        {label}
+      </FormLabel>
+      <Input {...rest} ref={ref} />
+      <FormErrorMessage>{error?.message}</FormErrorMessage>
+    </FormControl>
+  )
+);
+
+PlanInput.displayName = "PlanInput";

--- a/packages/frontend-v2/components/Form/Select.tsx
+++ b/packages/frontend-v2/components/Form/Select.tsx
@@ -15,6 +15,7 @@ type PlanSelectProps = {
   label: string;
   array: Key[];
 };
+
 export const PlanSelect = forwardRef<
   PlanSelectProps,
   ComponentWithAs<"select", SelectProps>

--- a/packages/frontend-v2/components/Form/Select.tsx
+++ b/packages/frontend-v2/components/Form/Select.tsx
@@ -1,0 +1,35 @@
+import {
+  FormControl,
+  forwardRef,
+  SelectProps,
+  FormLabel,
+  Select,
+  ComponentWithAs,
+  FormErrorMessage,
+} from "@chakra-ui/react";
+import { Key } from "react";
+import { FieldError } from "react-hook-form";
+
+type PlanSelectProps = {
+  error?: FieldError;
+  label: string;
+  array: Key[];
+};
+export const PlanSelect = forwardRef<
+  PlanSelectProps,
+  ComponentWithAs<"select", SelectProps>
+>(({ error, label, array, ...rest }, ref) => (
+  <FormControl isInvalid={error != null}>
+    <FormLabel color="primary.red.main" size="md" fontWeight="medium" mb="2xs">
+      {label}
+    </FormLabel>
+    <Select {...rest} ref={ref}>
+      {array.map((value) => (
+        <option key={value} value={value}>
+          {value}
+        </option>
+      ))}
+    </Select>
+    <FormErrorMessage>{error?.message}</FormErrorMessage>
+  </FormControl>
+));

--- a/packages/frontend-v2/components/Form/index.ts
+++ b/packages/frontend-v2/components/Form/index.ts
@@ -1,3 +1,4 @@
-export * from './Input'
-export * from './InputGroup'
-export * from './FormSections'
+export * from "./Input";
+export * from "./InputGroup";
+export * from "./FormSections";
+export * from "./Select";

--- a/packages/frontend-v2/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend-v2/components/Plan/EditPlanModal.tsx
@@ -1,0 +1,152 @@
+import { EditIcon } from "@chakra-ui/icons";
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+  VStack,
+} from "@chakra-ui/react";
+import { API } from "@graduate/api-client";
+import { PlanModel, UpdatePlanDto } from "@graduate/common";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useSWRConfig } from "swr";
+import { USE_STUDENT_WITH_PLANS_SWR_KEY } from "../../hooks";
+import { handleApiClientError } from "../../utils";
+import { toast } from "../../utils";
+import { BlueButton } from "../Button";
+import { PlanInput, PlanSelect } from "../Form";
+
+type EditPlanModalProps = {
+  plan: PlanModel<string> | undefined;
+  planId: number;
+};
+
+type EditPlanInput = {
+  name: string;
+  major: string;
+  catalogYear: number;
+};
+
+// Mock supported majors till we have scraped and stored majors
+const SUPPORTED_MAJORS = new Map<number, string[]>([
+  [
+    2019,
+    ["Computer Science, BSCS", "Computer Science and Cognitive Psycology, BS"],
+  ],
+  [2020, ["Computer Science, BSCS"]],
+]);
+
+export const EditPlanModal: React.FC<EditPlanModalProps> = ({
+  plan,
+  planId,
+}) => {
+  const { mutate } = useSWRConfig();
+  const router = useRouter();
+  const { onOpen, onClose, isOpen } = useDisclosure();
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty, errors, isSubmitting },
+    watch,
+    reset,
+  } = useForm<EditPlanInput>({
+    mode: "onTouched",
+    shouldFocusError: true,
+  });
+
+  useEffect(() => {
+    // Change the default field to the corresponding plan when a plan is selected/edited
+    reset({
+      name: plan?.name,
+      catalogYear: plan?.catalogYear,
+      major: plan?.major,
+    });
+  }, [plan, reset]);
+
+  const catalogYear = watch("catalogYear");
+
+  const onSubmitHandler = async (payload: UpdatePlanDto) => {
+    // If no field has been changed, don't send an update request
+    if (!isDirty) return;
+
+    try {
+      await API.plans.update(planId, payload);
+    } catch (error) {
+      handleApiClientError(error as Error, router);
+      return;
+    }
+
+    mutate(USE_STUDENT_WITH_PLANS_SWR_KEY);
+    toast.success("Update Plan Success");
+  };
+
+  return (
+    <>
+      <BlueButton leftIcon={<EditIcon />} onClick={onOpen} ml="xs" size="md">
+        Edit Plan
+      </BlueButton>
+
+      <Modal isOpen={isOpen} onClose={onClose} size="md">
+        <ModalOverlay />
+        <ModalContent>
+          <form onSubmit={handleSubmit(onSubmitHandler)}>
+            <ModalCloseButton />
+            <ModalHeader color="primary.red.main" fontSize="2xl">
+              Edit Plan
+            </ModalHeader>
+            <ModalBody>
+              <VStack spacing={"sm"}>
+                <PlanInput
+                  error={errors.name}
+                  label={"Title"}
+                  type={"text"}
+                  id="name"
+                  placeholder="My Plan"
+                  {...register("name", {
+                    required: "Title is required",
+                  })}
+                />
+
+                <PlanSelect
+                  label={"Catalog Year"}
+                  id="catalogYear"
+                  placeholder="Select a Catalog Year"
+                  error={errors.catalogYear}
+                  array={Array.from(SUPPORTED_MAJORS.keys())}
+                  {...register("catalogYear", {
+                    required: "Catalog year is required",
+                    valueAsNumber: true,
+                  })}
+                />
+
+                <PlanSelect
+                  label={"Major"}
+                  id="major"
+                  placeholder="Select a Major"
+                  error={errors.major}
+                  array={SUPPORTED_MAJORS.get(catalogYear) ?? []}
+                  {...register("major", {
+                    required: "Major is required",
+                  })}
+                />
+              </VStack>
+            </ModalBody>
+
+            <ModalFooter>
+              <Button isLoading={isSubmitting} type="submit" ml="auto">
+                Edit Plan
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/packages/frontend-v2/components/Plan/index.ts
+++ b/packages/frontend-v2/components/Plan/index.ts
@@ -1,3 +1,4 @@
 export * from "./Plan";
 export * from "./PlanDropdown";
 export * from "./AddPlanModal";
+export * from "./EditPlanModal";

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from "next";
 import {
   AddPlanModal,
+  EditPlanModal,
   BlueButton,
   HeaderContainer,
   LoadingPage,
@@ -162,6 +163,9 @@ const HomePage: NextPage = () => {
               onClose={onCloseAddPlanModal}
               isOpen={isOpenAddPlanModal}
             />
+            {selectedPlanId && (
+              <EditPlanModal plan={selectedPlan} planId={selectedPlanId} />
+            )}
           </Flex>
           {selectedPlan && (
             <Plan

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -2,7 +2,6 @@ import { NextPage } from "next";
 import {
   AddPlanModal,
   EditPlanModal,
-  BlueButton,
   HeaderContainer,
   LoadingPage,
   Logo,
@@ -22,18 +21,12 @@ import {
 import { API } from "@graduate/api-client";
 import { PlanModel } from "@graduate/common";
 import { useRouter } from "next/router";
-import { Button, Flex, Grid, GridItem, useDisclosure } from "@chakra-ui/react";
+import { Button, Flex, Grid, GridItem } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
-import { AddIcon } from "@chakra-ui/icons";
 
 const HomePage: NextPage = () => {
   const { error, student, mutateStudent } = useStudentWithPlans();
   const router = useRouter();
-  const {
-    onOpen: onOpenAddPlanModal,
-    onClose: closeAddPlanModalDisplay,
-    isOpen: isOpenAddPlanModal,
-  } = useDisclosure();
 
   /*
    * Keep track of the plan being displayed, initially undef and later either the plan id or null.
@@ -141,12 +134,12 @@ const HomePage: NextPage = () => {
     });
   };
 
-  const onCloseAddPlanModal = (newPlanId?: number) => {
-    if (newPlanId) {
-      setSelectedPlanId(newPlanId);
-    }
-    closeAddPlanModalDisplay();
-  };
+  // const onCloseAddPlanModal = (newPlanId?: number) => {
+  //   if (newPlanId) {
+  //     setSelectedPlanId(newPlanId);
+  //   }
+  //   closeAddPlanModalDisplay();
+  // };
 
   return (
     <PageLayout>
@@ -158,11 +151,7 @@ const HomePage: NextPage = () => {
               setSelectedPlanId={setSelectedPlanId}
               plans={student.plans}
             />
-            <AddPlanButton
-              onOpen={onOpenAddPlanModal}
-              onClose={onCloseAddPlanModal}
-              isOpen={isOpenAddPlanModal}
-            />
+            <AddPlanModal setSelectedPlanId={setSelectedPlanId} />
             {selectedPlanId && (
               <EditPlanModal plan={selectedPlan} planId={selectedPlanId} />
             )}
@@ -176,27 +165,6 @@ const HomePage: NextPage = () => {
         </Flex>
       </DndContext>
     </PageLayout>
-  );
-};
-
-interface AddPlanButtonProps {
-  onOpen: () => void;
-  onClose: (newPlanId?: number) => void;
-  isOpen: boolean;
-}
-
-const AddPlanButton: React.FC<AddPlanButtonProps> = ({
-  onOpen,
-  onClose,
-  isOpen,
-}) => {
-  return (
-    <>
-      <BlueButton leftIcon={<AddIcon />} onClick={onOpen} ml="xs" size="md">
-        Add Plan
-      </BlueButton>
-      <AddPlanModal onClose={onClose} isOpen={isOpen} />
-    </>
   );
 };
 


### PR DESCRIPTION
# Description

Add an Edit Plan button that edit the name, catalog year and the major of the current plan


https://user-images.githubusercontent.com/75349763/196054929-72af0aff-65a4-48e0-aefb-5a6da41d9da4.mov


Closes #452

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`

# How Has This Been Tested?
- [x] Adding a new plan using the new plan modal and edit it using the edit plan modal 
- [ x ] Checking the data changes using Postman


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
