### PR TITLE
Add credit information to sidebar class data

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -87,6 +87,21 @@ interface SearchClass {
   minCredits: number;
 }
 
+function occurrenceToCourse(occurrence): ScheduleCourse2<null> | null {
+  if (!occurrence) return null;
+
+  return {
+    name: occurrence.name,
+    subject: occurrence.subject,
+    classId: occurrence.classId,
+    numCreditsMax: occurrence.maxCredits,
+    numCreditsMin: occurrence.minCredits,
+    prereqs: occurrence.prereqs,
+    coreqs: occurrence.coreqs,
+    id: null,
+  };
+}
+
 /**
  * A client for interacting with the Search API. Allows us to fetch and search
  * for courses.
@@ -122,16 +137,7 @@ class SearchAPIClient {
     });
 
     const courseData = await res.data.data;
-    if (courseData?.class?.latestOccurrence) {
-      const course: ScheduleCourse2<null> = courseData.class.latestOccurrence;
-      course.numCreditsMax = courseData.class.latestOccurrence.maxCredits;
-      course.numCreditsMin = courseData.class.latestOccurrence.minCredits;
-      delete courseData.class.latestOccurrence.maxCredits;
-      delete courseData.class.latestOccurrence.minCredits;
-      return course;
-    } else {
-      return null;
-    }
+    return occurrenceToCourse(courseData?.class?.latestOccurrence);
   };
 
   fetchCourses = async (
@@ -149,13 +155,15 @@ class SearchAPIClient {
       data: {
         query: `{
           bulkClasses(input: [${input}]) {
-            name
-            classId
-            subject
             latestOccurrence {
-              termId
+              name
+              subject
+              classId
               minCredits
               maxCredits
+              prereqs
+              coreqs
+              termId
             }
           }
         }`,
@@ -166,15 +174,7 @@ class SearchAPIClient {
 
     if (coursesData.bulkClasses) {
       return coursesData.bulkClasses.map((course) => {
-        if (course === null) return null;
-
-        return {
-          name: course.name,
-          classId: course.classId,
-          subject: course.subject,
-          numCreditsMin: course?.latestOccurrence?.minCredits,
-          numCreditsMax: course?.latestOccurrence?.maxCredits,
-        };
+        return occurrenceToCourse(course?.latestOccurrence);
       });
     } else {
       return null;

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -154,6 +154,8 @@ class SearchAPIClient {
             subject
             latestOccurrence {
               termId
+              minCredits
+              maxCredits
             }
           }
         }`,
@@ -163,7 +165,17 @@ class SearchAPIClient {
     const coursesData = await res.data.data;
 
     if (coursesData.bulkClasses) {
-      return coursesData.bulkClasses;
+      return coursesData.bulkClasses.map((course) => {
+        if (course === null) return null;
+
+        return {
+          name: course.name,
+          classId: course.classId,
+          subject: course.subject,
+          numCreditsMin: course?.latestOccurrence?.minCredits,
+          numCreditsMax: course?.latestOccurrence?.maxCredits,
+        };
+      });
     } else {
       return null;
     }

--- a/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
+++ b/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
@@ -116,7 +116,12 @@ const SectionRequirement: React.FC<SidebarRequirementProps> = ({
         />
       );
     }
-    return <p>Course not found</p>;
+    return (
+      <p>
+        Course not found ({requirement.subject}
+        {requirement.classId})
+      </p>
+    );
   };
 
   const renderSection = (requirement: Section) => {


### PR DESCRIPTION
# Description

Small fix to get class credits information from Search's API. Also made missing courses display their subject + classId so it's easier to debug missing classes later and provides some extra info to users.

Closes #492

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manually tested by checking that the credits add up properly in the semesters now.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
