### PR TITLE
Fix drag-and-drop IDs not increasing in plan properly

### DIFF
--- a/packages/frontend-v2/utils/plan/preparePlanForDnd.ts
+++ b/packages/frontend-v2/utils/plan/preparePlanForDnd.ts
@@ -41,19 +41,19 @@ export const prepareYearForDnd = (
 ) => {
   let res;
   let updatedCount = courseCount;
-  res = prepareTermForDnd(year.fall, courseCount);
+  res = prepareTermForDnd(year.fall, updatedCount);
   const dndFallTerm = res.dndTerm;
   updatedCount = res.updatedCount;
 
-  res = prepareTermForDnd(year.spring, courseCount);
+  res = prepareTermForDnd(year.spring, updatedCount);
   const dndSpringTerm = res.dndTerm;
   updatedCount = res.updatedCount;
 
-  res = prepareTermForDnd(year.summer1, courseCount);
+  res = prepareTermForDnd(year.summer1, updatedCount);
   const dndSummer1Term = res.dndTerm;
   updatedCount = res.updatedCount;
 
-  res = prepareTermForDnd(year.summer2, courseCount);
+  res = prepareTermForDnd(year.summer2, updatedCount);
   const dndSummer2Term = res.dndTerm;
   updatedCount = res.updatedCount;
 


### PR DESCRIPTION
# Description

There was a change made that broke increasing IDs in the preparePlanForDnd function which meant that when you tried to drag one class, it would often drag another with the same subject + classId as they had identical IDs.

Closes #497 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I confirmed that drag-and-drop IDs now increase for every class again using React Dev Tools and made sure that classes with the same subject + classId can be dragged properly and independently.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
