### PR TITLE
Fix Safari Styling Issues

### DIFF
--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -104,12 +104,12 @@ export const Plan: React.FC<PlanProps> = ({
         const isExpanded = expandedYears.has(scheduleYear.year);
 
         return (
-          <Box
+          <Flex
             key={scheduleYear.year}
             borderX="1px"
             borderBottom="1px"
             borderColor={isExpanded ? undefined : "primary.blue.light.main"}
-            minHeight={isExpanded ? "300px" : undefined}
+            flexDirection="column"
           >
             <ScheduleYear
               scheduleYear={scheduleYear}
@@ -124,7 +124,7 @@ export const Plan: React.FC<PlanProps> = ({
                 removeYearFromCurrPlan(scheduleYear.year)
               }
             />
-          </Box>
+          </Flex>
         );
       })}
     </Flex>

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import {
   PlanModel,
   ScheduleCourse2,

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -106,8 +106,9 @@ export const Plan: React.FC<PlanProps> = ({
         return (
           <Box
             key={scheduleYear.year}
-            borderX={isExpanded ? "1px" : undefined}
-            borderBottom={isExpanded ? "1px" : undefined}
+            borderX="1px"
+            borderBottom="1px"
+            borderColor={isExpanded ? undefined : "primary.blue.light.main"}
             minHeight={isExpanded ? "300px" : undefined}
           >
             <ScheduleYear

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -136,8 +136,16 @@ const YearHeader: React.FC<YearHeaderProps> = ({
     <Flex
       alignItems="center"
       backgroundColor={backgroundColor + ".main"}
+      _hover={
+        {
+          // backgroundColor: "primary.blue.light.600"
+        }
+      }
+      transition="background-color 0.15s ease"
       paddingTop="sm"
       paddingBottom="sm"
+      onClick={toggleExpanded}
+      cursor="pointer"
     >
       <Flex flexDirection="column" marginLeft="md">
         <Text color="white">Year {year.year}</Text>
@@ -154,36 +162,23 @@ const YearHeader: React.FC<YearHeaderProps> = ({
       >
         
       </YearHeaderColumnContainer> */}
-      <YearHeaderColumnContainer
-        colSpan={10}
-        pl="md"
-        bg={`${backgroundColor}.main`}
-        _groupHover={{ backgroundColor: hoverBackgrounColor }}
-      >
-        <Text color="white">{totalCreditsTaken} credits</Text>
-      </YearHeaderColumnContainer>
-      <YearHeaderColumnContainer
-        colSpan={1}
-        justifyContent="right"
-        bg={`${backgroundColor}.main`}
-        _groupHover={{ backgroundColor: hoverBackgrounColor }}
-      >
-        <Tooltip label={`Delete year ${year.year}?`} fontSize="md">
-          <IconButton
-            aria-label="Delete course"
-            variant="ghost"
-            color="primary.red.main"
-            icon={<DeleteIcon />}
-            _hover={{ bg: `${backgroundColor}.900` }}
-            _active={{ bg: `${backgroundColor}.900` }}
-            onClick={(e) => {
-              // important to prevent the click from propogating upwards and triggering the toggle
-              e.stopPropagation();
-              removeYearFromCurrPlan();
-            }}
-          />
-        </Tooltip>
-      </YearHeaderColumnContainer>
+      <Tooltip label={`Delete year ${year.year}?`} fontSize="md">
+        <IconButton
+          aria-label="Delete course"
+          variant="ghost"
+          color="white"
+          icon={<DeleteIcon />}
+          marginLeft="auto"
+          marginRight="sm"
+          _hover={{ bg: "white", color: "primary.red.main" }}
+          _active={{ bg: `${backgroundColor}.900` }}
+          onClick={(e) => {
+            // important to prevent the click from propogating upwards and triggering the toggle
+            e.stopPropagation();
+            removeYearFromCurrPlan();
+          }}
+        />
+      </Tooltip>
     </Flex>
   );
 };

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -133,23 +133,27 @@ const YearHeader: React.FC<YearHeaderProps> = ({
     : "primary.blue.light.700";
 
   return (
-    <Grid
-      templateColumns="repeat(12, 1fr)"
+    <Flex
       alignItems="center"
-      onClick={toggleExpanded}
-      role="group"
+      backgroundColor={backgroundColor + ".main"}
+      paddingTop="sm"
+      paddingBottom="sm"
     >
-      <YearHeaderColumnContainer
+      <Flex flexDirection="column" marginLeft="md">
+        <Text color="white">Year {year.year}</Text>
+        <Text color="white" fontWeight="bold">
+          {totalCreditsTaken} credits
+        </Text>
+      </Flex>
+      {/* <YearHeaderColumnContainer
         colSpan={1}
         justifyContent="center"
         mr="5xs"
         bg={`${backgroundColor}.main`}
         _groupHover={{ backgroundColor: hoverBackgrounColor }}
       >
-        <Text fontWeight="bold" color="white">
-          Year {year.year}
-        </Text>
-      </YearHeaderColumnContainer>
+        
+      </YearHeaderColumnContainer> */}
       <YearHeaderColumnContainer
         colSpan={10}
         pl="md"
@@ -180,7 +184,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
           />
         </Tooltip>
       </YearHeaderColumnContainer>
-    </Grid>
+    </Flex>
   );
 };
 

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -140,15 +140,6 @@ const YearHeader: React.FC<YearHeaderProps> = ({
           {totalCreditsTaken} credits
         </Text>
       </Flex>
-      {/* <YearHeaderColumnContainer
-        colSpan={1}
-        justifyContent="center"
-        mr="5xs"
-        bg={`${backgroundColor}.main`}
-        _groupHover={{ backgroundColor: hoverBackgrounColor }}
-      >
-        
-      </YearHeaderColumnContainer> */}
       <Tooltip label={`Delete year ${year.year}?`} fontSize="md">
         <IconButton
           aria-label="Delete course"

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -1,13 +1,5 @@
 import { DeleteIcon } from "@chakra-ui/icons";
-import {
-  Flex,
-  Grid,
-  GridItem,
-  GridItemProps,
-  IconButton,
-  Text,
-  Tooltip,
-} from "@chakra-ui/react";
+import { Flex, Grid, IconButton, Text, Tooltip } from "@chakra-ui/react";
 import { ScheduleCourse2, ScheduleYear2, SeasonEnum } from "@graduate/common";
 import { ScheduleTerm } from "./ScheduleTerm";
 
@@ -128,10 +120,6 @@ const YearHeader: React.FC<YearHeaderProps> = ({
     ? "primary.blue.dark"
     : "primary.blue.light";
 
-  const hoverBackgrounColor = isExpanded
-    ? "primary.blue.dark.700"
-    : "primary.blue.light.700";
-
   return (
     <Flex
       alignItems="center"
@@ -179,17 +167,5 @@ const YearHeader: React.FC<YearHeaderProps> = ({
         />
       </Tooltip>
     </Flex>
-  );
-};
-
-/** A GridItem container for the columns in a year header */
-const YearHeaderColumnContainer: React.FC<GridItemProps> = ({
-  children,
-  ...rest
-}) => {
-  return (
-    <GridItem display="flex" alignItems="center" {...rest}>
-      {children}
-    </GridItem>
   );
 };

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -68,7 +68,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
   }, 0);
 
   return (
-    <Flex flexDirection="column" height="100%" minHeight="inherit">
+    <Flex flexDirection="column">
       <YearHeader
         year={scheduleYear}
         totalCreditsTaken={totalCreditsThisYear}
@@ -77,7 +77,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
         removeYearFromCurrPlan={removeYearFromCurrPlan}
       />
       {isExpanded && (
-        <Grid templateColumns="repeat(4, 1fr)" flex={1}>
+        <Grid templateColumns="repeat(4, 1fr)" minHeight="220px">
           <ScheduleTerm
             scheduleTerm={scheduleYear.fall}
             isCourseInCurrPlan={isCourseInCurrPlan}
@@ -136,16 +136,15 @@ const YearHeader: React.FC<YearHeaderProps> = ({
     <Flex
       alignItems="center"
       backgroundColor={backgroundColor + ".main"}
-      _hover={
-        {
-          // backgroundColor: "primary.blue.light.600"
-        }
-      }
+      _hover={{
+        backgroundColor: "primary.blue.light.600",
+      }}
       transition="background-color 0.15s ease"
       paddingTop="sm"
       paddingBottom="sm"
       onClick={toggleExpanded}
       cursor="pointer"
+      userSelect="none"
     >
       <Flex flexDirection="column" marginLeft="md">
         <Text color="white">Year {year.year}</Text>
@@ -189,7 +188,7 @@ const YearHeaderColumnContainer: React.FC<GridItemProps> = ({
   ...rest
 }) => {
   return (
-    <GridItem height="100%" display="flex" alignItems="center" {...rest}>
+    <GridItem display="flex" alignItems="center" {...rest}>
       {children}
     </GridItem>
   );


### PR DESCRIPTION
# Description

Fixes styling in Safari and brings the styling more in-line with the current styling plans on Figma.

Styling in Safari with this PR:
![Image of the newly fixed page in Safari](https://user-images.githubusercontent.com/2746893/199148789-4a6dd946-ccbf-4f06-9868-78e9e2bfb842.png)

Closes #483 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I manually checked to see if it looks right and drag-and-drop still works properly in Safari, Firefox, and Microsoft Edge (chromium).

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
