### PR TITLE
Frontend Coreq and Prereq Errors

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -4,8 +4,8 @@ import {
   SignUpStudentDto,
   GetPlanResponse,
   GetStudentResponse,
-  INEUAndPrereq,
-  INEUOrPrereq,
+  INEUAndReq,
+  INEUOrReq,
   LoginStudentDto,
   UpdatePlanDto,
   UpdatePlanResponse,
@@ -81,8 +81,8 @@ interface SearchClass {
   name: string;
   classId: string;
   subject: string;
-  prereqs?: INEUAndPrereq | INEUOrPrereq;
-  coreqs?: INEUAndPrereq | INEUOrPrereq;
+  prereqs?: INEUAndReq | INEUOrReq;
+  coreqs?: INEUAndReq | INEUOrReq;
   maxCredits: number;
   minCredits: number;
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -104,17 +104,17 @@ export interface INEUPrereqOrError {
   missing: INEUPrereqError[];
 }
 
-export interface courseError {
-  [key: string]: INEUPrereqError | undefined;
+export interface CourseError {
+  [key: string]: INEUPrereqError | undefined
 }
 
-export interface preReqWarnings {
+export interface PreReqWarnings {
   [key: string]: {
-    fall: courseError;
-    spring: courseError;
-    summer1: courseError;
-    summer2: courseError;
-  };
+    fall: CourseError,
+    spring: CourseError,
+    summer1: CourseError,
+    summer2: CourseError
+  }
 }
 
 //                                       NEW MAJOR OBJECT HERE

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -104,17 +104,29 @@ export interface INEUPrereqOrError {
   missing: INEUPrereqError[];
 }
 
-export interface CourseError {
+export interface TermError {
   [key: string]: INEUPrereqError | undefined
 }
 
-export interface PreReqWarnings {
-  [key: string]: {
-    fall: CourseError,
-    spring: CourseError,
-    summer1: CourseError,
-    summer2: CourseError
-  }
+export interface ScheduleWarnings {
+  type: string
+  years: YearError[]
+}
+
+export interface YearError {
+  year: number;
+  fall: TermError,
+  spring: TermError,
+  summer1: TermError,
+  summer2: TermError
+}
+
+export type PreReqWarnings = ScheduleWarnings & {
+  type: "prereq"
+}
+
+export type CoReqWarnings = ScheduleWarnings & {
+  type: "coreq"
 }
 
 //                                       NEW MAJOR OBJECT HERE

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -45,7 +45,7 @@ export type Status = keyof typeof StatusEnum;
 export type Season = keyof typeof SeasonEnum;
 
 /** A SearchNEU prerequisite object. */
-export type INEUPrereq = INEUAndPrereq | INEUOrPrereq | INEUPrereqCourse;
+export type INEUPrereq = INEUAndReq | INEUOrReq | INEUReqCourse;
 /**
  * A SearchNEU AND prerequisite object.
  *
@@ -53,7 +53,7 @@ export type INEUPrereq = INEUAndPrereq | INEUOrPrereq | INEUPrereqCourse;
  * @param values The prerequisites that must be completed for this prereq. to be
  *   marked as done.
  */
-export interface INEUAndPrereq {
+export interface INEUAndReq {
   type: "and";
   values: INEUPrereq[];
 }
@@ -65,7 +65,7 @@ export interface INEUAndPrereq {
  * @param values The prerequisites of which one must be completed for this
  *   prerequisite to be marked as done.
  */
-export interface INEUOrPrereq {
+export interface INEUOrReq {
   type: "or";
   values: INEUPrereq[];
 }
@@ -77,35 +77,35 @@ export interface INEUOrPrereq {
  * @param subject The subject of this prerequisite course.
  * @param missing True if the class is missing.
  */
-export interface INEUPrereqCourse {
+export interface INEUReqCourse {
   classId: string;
   subject: string;
   missing?: true;
 }
 
-export type INEUPrereqError =
-  | INEUPreReqCourseError
-  | INEUPrereqAndError
-  | INEUPrereqOrError;
+export type INEUReqError =
+  | INEUReqCourseError
+  | INEUReqAndError
+  | INEUReqOrError;
 
-export interface INEUPreReqCourseError {
+export interface INEUReqCourseError {
   type: "course";
   subject: string;
   classId: string;
 }
 
-export interface INEUPrereqAndError {
+export interface INEUReqAndError {
   type: "and";
-  missing: INEUPrereqError[];
+  missing: INEUReqError[];
 }
 
-export interface INEUPrereqOrError {
+export interface INEUReqOrError {
   type: "or";
-  missing: INEUPrereqError[];
+  missing: INEUReqError[];
 }
 
 export interface TermError {
-  [key: string]: INEUPrereqError | undefined
+  [key: string]: INEUReqError | undefined
 }
 
 export interface ScheduleWarnings {
@@ -326,8 +326,8 @@ export interface ScheduleCourse2<T> {
   name: string;
   classId: string;
   subject: string;
-  prereqs?: INEUAndPrereq | INEUOrPrereq;
-  coreqs?: INEUAndPrereq | INEUOrPrereq;
+  prereqs?: INEUAndReq | INEUOrReq;
+  coreqs?: INEUAndReq | INEUOrReq;
   numCreditsMin: number;
   numCreditsMax: number;
   id: T;
@@ -400,8 +400,8 @@ export interface ScheduleCourse {
   name: string;
   classId: string; // Should this be a number?
   subject: string;
-  prereqs?: INEUAndPrereq | INEUOrPrereq;
-  coreqs?: INEUAndPrereq | INEUOrPrereq;
+  prereqs?: INEUAndReq | INEUOrReq;
+  coreqs?: INEUAndReq | INEUOrReq;
   numCreditsMin: number;
   numCreditsMax: number;
   semester?: string | null;

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -1,6 +1,8 @@
 import { Flex } from "@chakra-ui/react";
 import {
+  CoReqWarnings,
   PlanModel,
+  PreReqWarnings,
   ScheduleCourse2,
   ScheduleYear2,
   SeasonEnum
@@ -12,6 +14,8 @@ import { ScheduleYear } from "./ScheduleYear";
 
 interface PlanProps {
   plan: PlanModel<string>;
+  preReqErr: PreReqWarnings | undefined;
+  coReqErr: CoReqWarnings | undefined;
 
   /**
    * Function to POST the plan and update the SWR cache for "student with plans"
@@ -23,6 +27,8 @@ interface PlanProps {
 export const Plan: React.FC<PlanProps> = ({
   plan,
   mutateStudentWithUpdatedPlan,
+  preReqErr,
+  coReqErr,
 }) => {
   const [expandedYears, setExpandedYears] = useState<Set<number>>(new Set());
 
@@ -108,6 +114,12 @@ export const Plan: React.FC<PlanProps> = ({
             flexDirection="column"
           >
             <ScheduleYear
+              yearCoReqError={coReqErr?.years.find(
+                (year) => year.year == scheduleYear.year
+              )}
+              yearPreReqError={preReqErr?.years.find(
+                (year) => year.year == scheduleYear.year
+              )}
               scheduleYear={scheduleYear}
               isExpanded={isExpanded}
               toggleExpanded={() => toggleExpanded(scheduleYear)}

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -5,7 +5,7 @@ import {
   PreReqWarnings,
   ScheduleCourse2,
   ScheduleYear2,
-  SeasonEnum
+  SeasonEnum,
 } from "@graduate/common";
 import { useState } from "react";
 import { addClassesToTerm, removeYearFromPlan } from "../../utils";
@@ -14,8 +14,8 @@ import { ScheduleYear } from "./ScheduleYear";
 
 interface PlanProps {
   plan: PlanModel<string>;
-  preReqErr: PreReqWarnings | undefined;
-  coReqErr: CoReqWarnings | undefined;
+  preReqErr?: PreReqWarnings;
+  coReqErr?: CoReqWarnings;
 
   /**
    * Function to POST the plan and update the SWR cache for "student with plans"
@@ -27,8 +27,8 @@ interface PlanProps {
 export const Plan: React.FC<PlanProps> = ({
   plan,
   mutateStudentWithUpdatedPlan,
-  preReqErr,
-  coReqErr,
+  preReqErr = undefined,
+  coReqErr = undefined,
 }) => {
   const [expandedYears, setExpandedYears] = useState<Set<number>>(new Set());
 

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -3,7 +3,7 @@ import {
   PlanModel,
   ScheduleCourse2,
   ScheduleYear2,
-  SeasonEnum,
+  SeasonEnum
 } from "@graduate/common";
 import { useState } from "react";
 import { addClassesToTerm, removeYearFromPlan } from "../../utils";

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -31,13 +31,26 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
-    <>
+    <Flex
+      justifySelf="stretch"
+      alignSelf="stretch"
+      _hover={{
+        background: "primary.red.main",
+        fill: "white",
+        svg: { color: "white" },
+      }}
+      _active={{ background: "primary.red.900" }}
+      onClick={() => {
+        onOpen();
+      }}
+    >
       <WarningIcon
         color="primary.red.main"
-        transition="color 0.1s ease"
-        onClick={() => {
-          onOpen();
-        }}
+        width="2rem"
+        alignSelf="center"
+        alignItems="center"
+        justifySelf="center"
+        transition="background 0.15s ease"
       />
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
@@ -77,7 +90,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
           </ModalFooter>
         </ModalContent>
       </Modal>
-    </>
+    </Flex>
   );
 };
 

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -1,0 +1,79 @@
+import { DeleteIcon } from "@chakra-ui/icons";
+import {
+  Button,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { API } from "@graduate/api-client";
+import { useRouter } from "next/router";
+import { mutate } from "swr";
+import { USE_STUDENT_WITH_PLANS_SWR_KEY } from "../../hooks";
+import { handleApiClientError } from "../../utils";
+import { GrayButton } from "../Button";
+
+interface DeletePlanModalProps {
+  planName: string;
+  planId: number;
+  onClose: (isDeleted: boolean, closeDisplay: () => void) => void;
+}
+export const DeletePlanModal: React.FC<DeletePlanModalProps> = ({
+  planName,
+  planId,
+  onClose,
+}) => {
+  const router = useRouter();
+  const { onOpen, onClose: closeDisplay, isOpen } = useDisclosure();
+
+  const closeWithoutDelete = () => {
+    onClose(false, closeDisplay);
+  };
+  const deletePlan = async () => {
+    try {
+      await API.plans.delete(planId);
+
+      // refresh the cache and close the modal
+      mutate(USE_STUDENT_WITH_PLANS_SWR_KEY);
+      onClose(true, closeDisplay);
+    } catch (error) {
+      handleApiClientError(error as Error, router);
+    }
+  };
+
+  return (
+    <>
+      <IconButton
+        icon={<DeleteIcon />}
+        aria-label="Delete plan"
+        variant="outline"
+        borderColor="primary.blue.light.main"
+        colorScheme="primary.blue.light"
+        color="primary.blue.light.main"
+        ml="xs"
+        onClick={onOpen}
+      />
+      <Modal isOpen={isOpen} onClose={closeWithoutDelete}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Delete Plan</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            Woah, are you sure you want to delete {planName}?
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={deletePlan}>
+              Delete
+            </Button>
+            <GrayButton onClick={closeWithoutDelete}>Nevermind</GrayButton>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -17,6 +17,7 @@ import {
   INEUPrereqError,
   ScheduleCourse2,
 } from "@graduate/common";
+import { useState } from "react";
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
@@ -29,6 +30,8 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   coReqErr,
   preReqErr,
 }) => {
+  const [page, setPage] = useState(0);
+
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Flex
@@ -69,14 +72,14 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
             <Text fontWeight="semibold" mb="xs">{`${courseToString(
               course
             )} requires the following:`}</Text>
-            {coReqErr && (
-              <Flex direction="column">
+            {coReqErr && page == 0 && (
+              <Flex direction="column" paddingX="sm">
                 <Text fontWeight="semibold">CoReq Errors</Text>
                 <ParseCourse course={coReqErr} />
               </Flex>
             )}
-            {preReqErr && (
-              <Flex direction="column">
+            {preReqErr && page == 1 && (
+              <Flex direction="column" paddingX="sm">
                 <Text fontWeight="semibold">PreReq Errors</Text>
                 <ParseCourse course={preReqErr} />
               </Flex>
@@ -84,9 +87,30 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
           </ModalBody>
 
           <ModalFooter>
-            <Button variant="outline" mr={3} onClick={onClose}>
-              Close
-            </Button>
+            <Flex
+              justifyContent="space-between"
+              width="100%"
+              alignItems="center"
+            >
+              <Button
+                variant="solidRed"
+                mr={3}
+                onClick={() => {
+                  onClose();
+                  setPage(0);
+                }}
+              >
+                Close
+              </Button>
+              <Text fontSize="sm">{`Page ${page + 1} of 2`}</Text>
+              <Button
+                variant="solidBlue"
+                mr={3}
+                onClick={() => setPage(page == 0 ? 1 : 0)}
+              >
+                {page == 0 ? "Next" : "Prev"}
+              </Button>
+            </Flex>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -1,21 +1,25 @@
 import { WarningIcon } from "@chakra-ui/icons";
 import {
-  Button, Flex, Modal,
-  ModalBody, ModalCloseButton,
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
-  ModalOverlay, Text, useDisclosure
+  ModalOverlay,
+  Text,
+  useDisclosure,
 } from "@chakra-ui/react";
 import {
   assertUnreachable,
   courseToString,
   INEUPrereqError,
-  ScheduleCourse2
+  ScheduleCourse2,
 } from "@graduate/common";
 
 interface ReqErrorModalProps {
-  course: ScheduleCourse2<string>,
+  course: ScheduleCourse2<string>;
   preReqErr: INEUPrereqError | undefined;
   coReqErr: INEUPrereqError | undefined;
 }
@@ -38,20 +42,38 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Course Errors for {courseToString(course)}</ModalHeader>
-          <ModalCloseButton />
+          <ModalHeader
+            textAlign="center"
+            backgroundColor="#D9D9D9"
+            borderTopRadius="md"
+          >
+            Course Errors for {courseToString(course)}
+          </ModalHeader>
           <ModalBody>
-            <Text fontSize="lg">CoReq Errors</Text>
-            <ParseCourse course={coReqErr} />
-            <Text fontSize="lg">PreReq Errors</Text>
-            <ParseCourse course={preReqErr} />
+            <Text fontSize="sm" mb="sm" color="red" textAlign="center">
+              It looks like you are missing prerequisites for this course
+            </Text>
+            <Text fontWeight="semibold" mb="xs">{`${courseToString(
+              course
+            )} requires the following:`}</Text>
+            {coReqErr && (
+              <Flex direction="column">
+                <Text fontWeight="semibold">CoReq Errors</Text>
+                <ParseCourse course={coReqErr} />
+              </Flex>
+            )}
+            {preReqErr && (
+              <Flex direction="column">
+                <Text fontWeight="semibold">PreReq Errors</Text>
+                <ParseCourse course={preReqErr} />
+              </Flex>
+            )}
           </ModalBody>
 
           <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={onClose}>
+            <Button variant='outline' mr={3} onClick={onClose}>
               Close
             </Button>
-            <Button variant="ghost">Secondary Action</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
@@ -71,11 +93,11 @@ const ParseCourse: React.FC<ParseCourseProps> = ({ course }) => {
 
   switch (course.type) {
     case "course":
-      return <Text fontSize="sm">{courseToString(course)}</Text>;
+      return <Text fontSize="md">{courseToString(course)}</Text>;
     case "and":
       return (
         <>
-          <Text fontSize="sm">AND</Text>
+          <Text fontSize="md">AND</Text>
           <Flex ml="1rem" direction="column">
             {course.missing.map((c, index) => (
               <ParseCourse course={c} key={index} />

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -17,7 +17,7 @@ import {
   INEUPrereqError,
   ScheduleCourse2,
 } from "@graduate/common";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
@@ -33,6 +33,16 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   const [page, setPage] = useState(0);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
+  useEffect(() => {
+    // if no coreq set default to page 2 (prereq page)
+    if (!coReqErr) {
+      setPage(1);
+      let onlyOne = true;
+    } else if (!preReqErr) {
+      setPage(0);
+      let onlyOne = true;
+    }
+  });
   return (
     <Flex
       justifySelf="stretch"

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -18,7 +18,6 @@ import {
   INEUPrereqError,
   ScheduleCourse2,
 } from "@graduate/common";
-import { useState } from "react";
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
@@ -31,10 +30,6 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   coReqErr,
   preReqErr,
 }) => {
-  const [page, setPage] = useState(0);
-  console.log(coReqErr);
-  console.log(preReqErr);
-
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Flex
@@ -58,7 +53,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
         justifySelf="center"
         transition="background 0.15s ease"
       />
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside">
         <ModalOverlay />
         <ModalContent>
           <ModalHeader
@@ -69,56 +64,34 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
             Course Errors for {courseToString(course)}
           </ModalHeader>
           <ModalBody>
-            <Text fontSize="sm" mb="sm" color="red" textAlign="center">
-              It looks like you are missing prerequisites for this course
-            </Text>
-            {coReqErr && page == 0 && (
-              <Flex direction="column">
-                <Text fontWeight="semibold" mb="xs" textAlign="center">
-                  CoReq Errors
-                </Text>
-                <ParseCourse course={coReqErr} parent={true} />
-              </Flex>
-            )}
-            {preReqErr && (page == 1 || !coReqErr) && (
-              <Flex direction="column">
-                <Text fontWeight="semibold" mb="xs" textAlign="center">
-                  PreReq Errors
-                </Text>
-                <ParseCourse course={preReqErr} parent={true} />
-              </Flex>
-            )}
+            <Flex direction="column">
+              <Text fontWeight="semibold" mb="xs" textAlign="center">
+                CoRequisite Errors
+              </Text>
+              <ParseCourse course={coReqErr} parent={true} />
+            </Flex>
+            <Flex direction="column">
+              <Text fontWeight="semibold" mb="xs" textAlign="center">
+                PreRequisite Errors
+              </Text>
+              <ParseCourse course={preReqErr} parent={true} />
+            </Flex>
           </ModalBody>
 
           <ModalFooter>
             <Flex
-              justifyContent="space-between"
+              justifyContent="end"
               width="100%"
               alignItems="center"
             >
               <Button
                 variant="solidRed"
                 mr={3}
-                onClick={() => {
-                  onClose();
-                  setPage(0);
-                }}
+                onClick={onClose}
               >
                 Close
               </Button>
-              {coReqErr && preReqErr && (
-                <Text fontSize="sm">{`Page ${page + 1} of 2`}</Text>
-              )}
-              {coReqErr && preReqErr && (
-                <Button
-                  variant="solidBlue"
-                  mr={3}
-                  onClick={() => setPage(page == 0 ? 1 : 0)}
-                >
-                  {page == 0 ? "Next" : "Prev"}
-                </Button>
-              )}
-            </Flex>
+            </Flex> 
           </ModalFooter>
         </ModalContent>
       </Modal>
@@ -154,7 +127,7 @@ const ParseCourse: React.FC<ParseCourseProps> = ({ course, parent }) => {
 
     case "and":
       return (
-        <Flex direction="column">
+        <>
           {course.missing.map((c, index) => (
             <Flex direction="column" key={index}>
               <BorderContainer>
@@ -167,50 +140,24 @@ const ParseCourse: React.FC<ParseCourseProps> = ({ course, parent }) => {
               )}
             </Flex>
           ))}
-          {/* {parent ? (
-            <BorderContainer>
-              {course.missing.map((c, index) => (
-                <Flex direction="column" key={index}>
-                  <ParseCourse course={c} parent={false} />
-                  {index < course.missing.length - 1 && (
-                    <Text fontSize="md" textAlign='center'>AND</Text>
-                  )}
-                </Flex>
-              ))}
-            </BorderContainer>
-          ) : (
-            <>
-              {course.missing.map((c, index) => (
-                <BorderContainer key={index}>
-                  <ParseCourse course={c} parent={false} />
-                  {index < course.missing.length - 1 && (
-                    <Text fontSize="md" textAlign='center'>AND</Text>
-                  )}
-                </BorderContainer>
-              ))}
-            </>
-          )} */}
-        </Flex>
+        </>
       );
     case "or":
       return (
-        <Flex direction="column">
+        <>
           {course.missing.map((c, index) => (
-            <Flex
-              direction="column"
-              justifyContent="center"
-              alignItems="center"
-              key={index}
-            >
+            <Flex direction="column" key={index}>
               <BorderContainer>
                 <ParseCourse course={c} parent={false} />
               </BorderContainer>
               {index < course.missing.length - 1 && (
-                <Text fontSize="md">OR</Text>
+                <Text fontSize="md" textAlign="center">
+                  OR
+                </Text>
               )}
             </Flex>
           ))}
-        </Flex>
+        </>
       );
     default:
       assertUnreachable(course);

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -10,24 +10,33 @@ import {
   useDisclosure,
   Button,
 } from "@chakra-ui/react";
+import { courseEq, courseToString, INEUPrereqError } from "@graduate/common";
 
-export const ReqErrorModal = ({}) => {
+interface ReqErrorModalProps {
+  preReqErr: INEUPrereqError | undefined;
+  coReqErr: INEUPrereqError | undefined;
+}
+
+export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
+  coReqErr,
+  preReqErr,
+}) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
       <WarningIcon
         color="primary.red.main"
         transition="color 0.1s ease"
-        onClick={onOpen}
+        onClick={() => {
+          onOpen();
+        }}
       />
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
-            <h1>helo hi yes</h1>
-          </ModalBody>
+          <ModalBody>{parseCourse(coReqErr)}</ModalBody>
 
           <ModalFooter>
             <Button colorScheme="blue" mr={3} onClick={onClose}>
@@ -39,4 +48,34 @@ export const ReqErrorModal = ({}) => {
       </Modal>
     </>
   );
+};
+
+// Look through the course error until there are no more errors!
+const parseCourse = (course: INEUPrereqError | undefined): string => {
+  if (course == undefined) {
+    return "";
+  }
+
+  let out = "";
+
+  switch (course["type"]) {
+    case "course":
+      // code block
+      out = courseToString(course);
+      break;
+    case "and":
+      for (const req of course.missing) {
+        out += parseCourse(req);
+      }
+      break;
+    case "or":
+      for (const req of course.missing) {
+        out += parseCourse(req);
+      }
+      break;
+    default:
+      return "idk :)";
+  }
+
+  return out;
 };

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -17,7 +17,7 @@ import {
   INEUPrereqError,
   ScheduleCourse2,
 } from "@graduate/common";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
@@ -33,16 +33,6 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   const [page, setPage] = useState(0);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
-  useEffect(() => {
-    // if no coreq set default to page 2 (prereq page)
-    if (!coReqErr) {
-      setPage(1);
-      let onlyOne = true;
-    } else if (!preReqErr) {
-      setPage(0);
-      let onlyOne = true;
-    }
-  });
   return (
     <Flex
       justifySelf="stretch"
@@ -79,18 +69,19 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
             <Text fontSize="sm" mb="sm" color="red" textAlign="center">
               It looks like you are missing prerequisites for this course
             </Text>
-            <Text fontWeight="semibold" mb="xs">{`${courseToString(
-              course
-            )} requires the following:`}</Text>
             {coReqErr && page == 0 && (
-              <Flex direction="column" paddingX="sm">
-                <Text fontWeight="semibold">CoReq Errors</Text>
+              <Flex direction="column">
+                <Text fontWeight="semibold" mb="xs" textAlign='center'>
+                  CoReq Errors
+                </Text>
                 <ParseCourse course={coReqErr} />
               </Flex>
             )}
-            {preReqErr && page == 1 && (
-              <Flex direction="column" paddingX="sm">
-                <Text fontWeight="semibold">PreReq Errors</Text>
+            {preReqErr && (page == 1 || !coReqErr) && (
+              <Flex direction="column">
+                <Text fontWeight="semibold" mb="xs" textAlign='center'>
+                  PreReq Errors
+                </Text>
                 <ParseCourse course={preReqErr} />
               </Flex>
             )}
@@ -112,14 +103,18 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
               >
                 Close
               </Button>
-              <Text fontSize="sm">{`Page ${page + 1} of 2`}</Text>
-              <Button
-                variant="solidBlue"
-                mr={3}
-                onClick={() => setPage(page == 0 ? 1 : 0)}
-              >
-                {page == 0 ? "Next" : "Prev"}
-              </Button>
+              {coReqErr && preReqErr && (
+                <Text fontSize="sm">{`Page ${page + 1} of 2`}</Text>
+              )}
+              {coReqErr && preReqErr && (
+                <Button
+                  variant="solidBlue"
+                  mr={3}
+                  onClick={() => setPage(page == 0 ? 1 : 0)}
+                >
+                  {page == 0 ? "Next" : "Prev"}
+                </Button>
+              )}
             </Flex>
           </ModalFooter>
         </ModalContent>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -154,37 +154,47 @@ const ParseCourse: React.FC<ParseCourseProps> = ({ course, parent }) => {
 
     case "and":
       return (
-        <Flex ml={parent ? "0" : "sm"} direction="column">
-          {parent ? (
+        <Flex direction="column">
+          {course.missing.map((c, index) => (
+            <Flex direction="column" key={index}>
+              <BorderContainer>
+                <ParseCourse course={c} parent={false} />
+              </BorderContainer>
+              {index < course.missing.length - 1 && (
+                <Text fontSize="md" textAlign="center">
+                  AND
+                </Text>
+              )}
+            </Flex>
+          ))}
+          {/* {parent ? (
+            <BorderContainer>
+              {course.missing.map((c, index) => (
+                <Flex direction="column" key={index}>
+                  <ParseCourse course={c} parent={false} />
+                  {index < course.missing.length - 1 && (
+                    <Text fontSize="md" textAlign='center'>AND</Text>
+                  )}
+                </Flex>
+              ))}
+            </BorderContainer>
+          ) : (
             <>
               {course.missing.map((c, index) => (
                 <BorderContainer key={index}>
-                  <Flex direction="column" key={index}>
-                    <ParseCourse course={c} parent={true} />
-                    {index < course.missing.length - 1 && (
-                      <Text fontSize="md">AND</Text>
-                    )}
-                  </Flex>
-                </BorderContainer>
-              ))}
-            </>
-          ) : (
-            <BorderContainer>
-              {course.missing.map((c, index) => (
-                <BorderContainer key={index}>
-                  <ParseCourse course={c} parent={true} />
+                  <ParseCourse course={c} parent={false} />
                   {index < course.missing.length - 1 && (
-                    <Text fontSize="md">AND</Text>
+                    <Text fontSize="md" textAlign='center'>AND</Text>
                   )}
                 </BorderContainer>
               ))}
-            </BorderContainer>
-          )}
+            </>
+          )} */}
         </Flex>
       );
     case "or":
       return (
-        <Flex ml={parent ? "0" : "sm"} direction="column">
+        <Flex direction="column">
           {course.missing.map((c, index) => (
             <Flex
               direction="column"
@@ -215,7 +225,7 @@ const BorderContainer: React.FC<React.PropsWithChildren> = ({ children }) => {
       borderWidth="thin"
       alignSelf="stretch"
       padding="xs"
-      marginY="xs"
+      margin="3xs"
       borderRadius="lg"
       borderColor="grey"
     >

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -1,76 +1,35 @@
-import { DeleteIcon } from "@chakra-ui/icons";
 import {
-  Button,
-  IconButton,
   Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
   ModalBody,
   ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   useDisclosure,
+  Button,
 } from "@chakra-ui/react";
-import { API } from "@graduate/api-client";
-import { useRouter } from "next/router";
-import { mutate } from "swr";
-import { USE_STUDENT_WITH_PLANS_SWR_KEY } from "../../hooks";
-import { handleApiClientError } from "../../utils";
-import { GrayButton } from "../Button";
 
-interface DeletePlanModalProps {
-  planName: string;
-  planId: number;
-  onClose: (isDeleted: boolean, closeDisplay: () => void) => void;
-}
-export const DeletePlanModal: React.FC<DeletePlanModalProps> = ({
-  planName,
-  planId,
-  onClose,
-}) => {
-  const router = useRouter();
-  const { onOpen, onClose: closeDisplay, isOpen } = useDisclosure();
-
-  const closeWithoutDelete = () => {
-    onClose(false, closeDisplay);
-  };
-  const deletePlan = async () => {
-    try {
-      await API.plans.delete(planId);
-
-      // refresh the cache and close the modal
-      mutate(USE_STUDENT_WITH_PLANS_SWR_KEY);
-      onClose(true, closeDisplay);
-    } catch (error) {
-      handleApiClientError(error as Error, router);
-    }
-  };
-
+export const ReqErrorModal = ({}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <IconButton
-        icon={<DeleteIcon />}
-        aria-label="Delete plan"
-        variant="outline"
-        borderColor="primary.blue.light.main"
-        colorScheme="primary.blue.light"
-        color="primary.blue.light.main"
-        ml="xs"
-        onClick={onOpen}
-      />
-      <Modal isOpen={isOpen} onClose={closeWithoutDelete}>
+      <Button onClick={onOpen}>Open Modal</Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>Delete Plan</ModalHeader>
+          <ModalHeader>Modal Title</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
-            Woah, are you sure you want to delete {planName}?
+            <h1>helo hi yes</h1>
           </ModalBody>
+
           <ModalFooter>
-            <Button mr={3} onClick={deletePlan}>
-              Delete
+            <Button colorScheme="blue" mr={3} onClick={onClose}>
+              Close
             </Button>
-            <GrayButton onClick={closeWithoutDelete}>Nevermind</GrayButton>
+            <Button variant="ghost">Secondary Action</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -15,14 +15,14 @@ import {
 import {
   assertUnreachable,
   courseToString,
-  INEUPrereqError,
+  INEUReqError,
   ScheduleCourse2,
 } from "@graduate/common";
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
-  preReqErr: INEUPrereqError | undefined;
-  coReqErr: INEUPrereqError | undefined;
+  preReqErr: INEUReqError | undefined;
+  coReqErr: INEUReqError | undefined;
 }
 
 export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
@@ -96,7 +96,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
 };
 
 interface ParseCourseProps {
-  course: INEUPrereqError | undefined;
+  course: INEUReqError | undefined;
   parent: boolean;
 }
 

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -64,34 +64,30 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
             Course Errors for {courseToString(course)}
           </ModalHeader>
           <ModalBody>
-            <Flex direction="column">
-              <Text fontWeight="semibold" mb="xs" textAlign="center">
-                CoRequisite Errors
-              </Text>
-              <ParseCourse course={coReqErr} parent={true} />
-            </Flex>
-            <Flex direction="column">
-              <Text fontWeight="semibold" mb="xs" textAlign="center">
-                PreRequisite Errors
-              </Text>
-              <ParseCourse course={preReqErr} parent={true} />
-            </Flex>
+            {coReqErr && (
+              <Flex direction="column">
+                <Text fontWeight="semibold" mb="xs" textAlign="center">
+                  CoRequisite Errors
+                </Text>
+                <ParseCourse course={coReqErr} parent={true} />
+              </Flex>
+            )}
+            {preReqErr && (
+              <Flex direction="column">
+                <Text fontWeight="semibold" mb="xs" textAlign="center">
+                  PreRequisite Errors
+                </Text>
+                <ParseCourse course={preReqErr} parent={true} />
+              </Flex>
+            )}
           </ModalBody>
 
           <ModalFooter>
-            <Flex
-              justifyContent="end"
-              width="100%"
-              alignItems="center"
-            >
-              <Button
-                variant="solidBlue"
-                mr={3}
-                onClick={onClose}
-              >
+            <Flex justifyContent="end" width="100%" alignItems="center">
+              <Button variant="solidBlue" mr={3} onClick={onClose}>
                 Close
               </Button>
-            </Flex> 
+            </Flex>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -21,14 +21,14 @@ import {
 
 interface ReqErrorModalProps {
   course: ScheduleCourse2<string>;
-  preReqErr: INEUReqError | undefined;
-  coReqErr: INEUReqError | undefined;
+  preReqErr?: INEUReqError;
+  coReqErr?: INEUReqError;
 }
 
 export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   course,
-  coReqErr,
-  preReqErr,
+  coReqErr = undefined,
+  preReqErr = undefined,
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
@@ -96,13 +96,16 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
 };
 
 interface ParseCourseProps {
-  course: INEUReqError | undefined;
+  course?: INEUReqError;
   parent: boolean;
 }
 
 // Look through the course error until there are no more errors!
 // TODO: Fix the styling!
-const ParseCourse: React.FC<ParseCourseProps> = ({ course, parent }) => {
+const ParseCourse: React.FC<ParseCourseProps> = ({
+  course = undefined,
+  parent,
+}) => {
   if (course == undefined) {
     return <></>;
   }

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -1,3 +1,4 @@
+import { WarningIcon } from "@chakra-ui/icons";
 import {
   Modal,
   ModalOverlay,
@@ -14,8 +15,11 @@ export const ReqErrorModal = ({}) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <>
-      <Button onClick={onOpen}>Open Modal</Button>
-
+      <WarningIcon
+        color="primary.red.main"
+        transition="color 0.1s ease"
+        onClick={onOpen}
+      />
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -71,7 +71,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
           </ModalBody>
 
           <ModalFooter>
-            <Button variant='outline' mr={3} onClick={onClose}>
+            <Button variant="outline" mr={3} onClick={onClose}>
               Close
             </Button>
           </ModalFooter>

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -85,7 +85,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
               alignItems="center"
             >
               <Button
-                variant="solidRed"
+                variant="solidBlue"
                 mr={3}
                 onClick={onClose}
               >

--- a/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
@@ -15,8 +15,8 @@ import { BlueButton } from "../Button";
 
 interface ScheduleTermProps {
   scheduleTerm: ScheduleTerm2<string>;
-  termCoReqErr: TermError | undefined;
-  termPreReqErr: TermError | undefined;
+  termCoReqErr?: TermError;
+  termPreReqErr?: TermError;
 
   /** Function to add classes to a given term in the plan being displayed. */
   addClassesToTermInCurrPlan: (
@@ -40,8 +40,8 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
   addClassesToTermInCurrPlan,
   removeCourseFromTermInCurrPlan,
   isLastColumn,
-  termCoReqErr,
-  termPreReqErr,
+  termCoReqErr = undefined,
+  termPreReqErr = undefined,
 }) => {
   const { isOver, setNodeRef } = useDroppable({ id: scheduleTerm.id });
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
@@ -1,5 +1,11 @@
 import { GridItem, Heading, useDisclosure } from "@chakra-ui/react";
-import { ScheduleCourse2, ScheduleTerm2, SeasonEnum } from "@graduate/common";
+import {
+  courseToString,
+  ScheduleCourse2,
+  ScheduleTerm2,
+  SeasonEnum,
+  TermError,
+} from "@graduate/common";
 import { DraggableScheduleCourse } from "../ScheduleCourse";
 import { useDroppable } from "@dnd-kit/core";
 import { getSeasonDisplayWord, isCourseInTerm } from "../../utils";
@@ -9,6 +15,8 @@ import { BlueButton } from "../Button";
 
 interface ScheduleTermProps {
   scheduleTerm: ScheduleTerm2<string>;
+  termCoReqErr: TermError | undefined;
+  termPreReqErr: TermError | undefined;
 
   /** Function to add classes to a given term in the plan being displayed. */
   addClassesToTermInCurrPlan: (
@@ -32,6 +40,8 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
   addClassesToTermInCurrPlan,
   removeCourseFromTermInCurrPlan,
   isLastColumn,
+  termCoReqErr,
+  termPreReqErr,
 }) => {
   const { isOver, setNodeRef } = useDroppable({ id: scheduleTerm.id });
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -59,6 +69,8 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
       />
       {scheduleTerm.classes.map((scheduleCourse) => (
         <DraggableScheduleCourse
+          coReqErr={termCoReqErr?.[courseToString(scheduleCourse)]}
+          preReqErr={termPreReqErr?.[courseToString(scheduleCourse)]}
           scheduleCourse={scheduleCourse}
           removeCourse={(course: ScheduleCourse2<unknown>) =>
             removeCourseFromTermInCurrPlan(

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -1,11 +1,5 @@
 import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
-import {
-  Flex,
-  Grid,
-  IconButton,
-  Text,
-  Tooltip,
-} from "@chakra-ui/react";
+import { Flex, Grid, IconButton, Text, Tooltip } from "@chakra-ui/react";
 import {
   ScheduleCourse2,
   ScheduleYear2,
@@ -22,8 +16,8 @@ interface ToggleYearProps {
 
 interface ScheduleYearProps extends ToggleYearProps {
   scheduleYear: ScheduleYear2<string>;
-  yearCoReqError: YearError | undefined;
-  yearPreReqError: YearError | undefined;
+  yearCoReqError?: YearError;
+  yearPreReqError?: YearError;
 
   /** Function to add classes to a given term in the plan being displayed. */
   addClassesToTermInCurrPlan: (
@@ -50,8 +44,8 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
   isExpanded,
   toggleExpanded,
   removeYearFromCurrPlan,
-  yearCoReqError,
-  yearPreReqError,
+  yearCoReqError = undefined,
+  yearPreReqError = undefined,
 }) => {
   // sum all credits over all the courses over each semester
   const totalCreditsThisYear = [

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -76,23 +76,16 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
   const [displayReqErrors, setDisplayReqErrors] = useState(false);
 
   useEffect(() => {
-    // if (yearCoReqError?.fall?.)
     const classes = [];
-    if (yearPreReqError?.fall)
-      for (const val of Object.values(yearPreReqError.fall))
-        if (val != undefined) classes.push(val);
-    if (yearPreReqError?.spring)
-      for (const val of Object.values(yearPreReqError.spring))
-        if (val != undefined) classes.push(val);
-    if (yearPreReqError?.summer1)
-      for (const val of Object.values(yearPreReqError.summer1))
-        if (val != undefined) classes.push(val);
-    if (yearPreReqError?.summer2)
-      for (const val of Object.values(yearPreReqError.summer2))
-        if (val != undefined) classes.push(val);
-
-    console.log(classes);
-    setDisplayReqErrors(classes.length > 0);
+    classes.push(...Object.values(yearPreReqError?.fall ?? {}));
+    classes.push(...Object.values(yearPreReqError?.spring ?? {}));
+    classes.push(...Object.values(yearPreReqError?.summer1 ?? {}));
+    classes.push(...Object.values(yearPreReqError?.summer2 ?? {}));
+    classes.push(...Object.values(yearCoReqError?.fall ?? {}));
+    classes.push(...Object.values(yearCoReqError?.spring ?? {}));
+    classes.push(...Object.values(yearCoReqError?.summer1 ?? {}));
+    classes.push(...Object.values(yearCoReqError?.summer2 ?? {}));
+    setDisplayReqErrors(classes.filter((c) => c != undefined).length > 0);
   }, [yearCoReqError, yearPreReqError]);
 
   return (

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -159,7 +159,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
   return (
     <Flex
       alignItems="center"
-      justifyContent='space-between'
+      justifyContent="space-between"
       backgroundColor={backgroundColor + ".main"}
       _hover={{
         backgroundColor: "primary.blue.light.600",
@@ -186,11 +186,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
               color="primary.red.main"
               icon={<WarningIcon />}
               _hover={{ bg: `white` }}
-              _active={{ }}
-              onClick={() => {
-                // open modal
-                console.log("open modal");
-              }}
+              _active={{}}
             />
           </Tooltip>
         )}

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -1,6 +1,19 @@
 import { DeleteIcon } from "@chakra-ui/icons";
-import { Flex, Grid, IconButton, Text, Tooltip } from "@chakra-ui/react";
-import { ScheduleCourse2, ScheduleYear2, SeasonEnum } from "@graduate/common";
+import {
+  Flex,
+  Grid,
+  GridItem,
+  GridItemProps,
+  IconButton,
+  Text,
+  Tooltip,
+} from "@chakra-ui/react";
+import {
+  ScheduleCourse2,
+  ScheduleYear2,
+  SeasonEnum,
+  YearError,
+} from "@graduate/common";
 import { ScheduleTerm } from "./ScheduleTerm";
 
 interface ToggleYearProps {
@@ -10,6 +23,8 @@ interface ToggleYearProps {
 
 interface ScheduleYearProps extends ToggleYearProps {
   scheduleYear: ScheduleYear2<string>;
+  yearCoReqError: YearError | undefined;
+  yearPreReqError: YearError | undefined;
 
   /** Function to add classes to a given term in the plan being displayed. */
   addClassesToTermInCurrPlan: (
@@ -36,6 +51,8 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
   isExpanded,
   toggleExpanded,
   removeYearFromCurrPlan,
+  yearCoReqError,
+  yearPreReqError,
 }) => {
   // sum all credits over all the courses over each semester
   const totalCreditsThisYear = [
@@ -67,22 +84,30 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
       {isExpanded && (
         <Grid templateColumns="repeat(4, 1fr)" minHeight="220px">
           <ScheduleTerm
+            termCoReqErr={yearCoReqError?.fall}
+            termPreReqErr={yearPreReqError?.fall}
             scheduleTerm={scheduleYear.fall}
             addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
             removeCourseFromTermInCurrPlan={removeCourseFromTermInCurrPlan}
           />
           <ScheduleTerm
+            termCoReqErr={yearCoReqError?.spring}
+            termPreReqErr={yearPreReqError?.spring}
             scheduleTerm={scheduleYear.spring}
             addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
             removeCourseFromTermInCurrPlan={removeCourseFromTermInCurrPlan}
           />
           {/* TODO: support summer full term */}
           <ScheduleTerm
+            termCoReqErr={yearCoReqError?.summer1}
+            termPreReqErr={yearPreReqError?.summer1}
             scheduleTerm={scheduleYear.summer1}
             addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
             removeCourseFromTermInCurrPlan={removeCourseFromTermInCurrPlan}
           />
           <ScheduleTerm
+            termCoReqErr={yearCoReqError?.summer2}
+            termPreReqErr={yearPreReqError?.summer2}
             scheduleTerm={scheduleYear.summer2}
             addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
             removeCourseFromTermInCurrPlan={removeCourseFromTermInCurrPlan}

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -1,9 +1,9 @@
-import { DeleteIcon } from "@chakra-ui/icons";
+import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
 import {
   Flex,
   Grid,
-  GridItem,
-  GridItemProps,
+  // GridItem,
+  // GridItemProps,
   IconButton,
   Text,
   Tooltip,
@@ -15,6 +15,7 @@ import {
   YearError,
 } from "@graduate/common";
 import { ScheduleTerm } from "./ScheduleTerm";
+import { useState, useEffect } from "react";
 
 interface ToggleYearProps {
   isExpanded: boolean;
@@ -72,6 +73,28 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
     return totalCreditsForYear + totalCreditsThisTerm;
   }, 0);
 
+  const [displayReqErrors, setDisplayReqErrors] = useState(false);
+
+  useEffect(() => {
+    // if (yearCoReqError?.fall?.)
+    const classes = [];
+    if (yearPreReqError?.fall)
+      for (const val of Object.values(yearPreReqError.fall))
+        if (val != undefined) classes.push(val);
+    if (yearPreReqError?.spring)
+      for (const val of Object.values(yearPreReqError.spring))
+        if (val != undefined) classes.push(val);
+    if (yearPreReqError?.summer1)
+      for (const val of Object.values(yearPreReqError.summer1))
+        if (val != undefined) classes.push(val);
+    if (yearPreReqError?.summer2)
+      for (const val of Object.values(yearPreReqError.summer2))
+        if (val != undefined) classes.push(val);
+
+    console.log(classes);
+    setDisplayReqErrors(classes.length > 0);
+  }, [yearCoReqError, yearPreReqError]);
+
   return (
     <Flex flexDirection="column">
       <YearHeader
@@ -80,6 +103,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
         isExpanded={isExpanded}
         toggleExpanded={toggleExpanded}
         removeYearFromCurrPlan={removeYearFromCurrPlan}
+        displayReqErrors={displayReqErrors}
       />
       {isExpanded && (
         <Grid templateColumns="repeat(4, 1fr)" minHeight="220px">
@@ -121,6 +145,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
 
 interface YearHeaderProps extends ToggleYearProps {
   year: ScheduleYear2<string>;
+  displayReqErrors: boolean;
   totalCreditsTaken: number;
   removeYearFromCurrPlan: () => void;
 }
@@ -132,6 +157,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
   isExpanded,
   toggleExpanded,
   removeYearFromCurrPlan,
+  displayReqErrors,
 }) => {
   const backgroundColor = isExpanded
     ? "primary.blue.dark"
@@ -140,6 +166,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
   return (
     <Flex
       alignItems="center"
+      justifyContent='space-between'
       backgroundColor={backgroundColor + ".main"}
       _hover={{
         backgroundColor: "primary.blue.light.600",
@@ -157,23 +184,41 @@ const YearHeader: React.FC<YearHeaderProps> = ({
           {totalCreditsTaken} credits
         </Text>
       </Flex>
-      <Tooltip label={`Delete year ${year.year}?`} fontSize="md">
-        <IconButton
-          aria-label="Delete course"
-          variant="ghost"
-          color="white"
-          icon={<DeleteIcon />}
-          marginLeft="auto"
-          marginRight="sm"
-          _hover={{ bg: "white", color: "primary.red.main" }}
-          _active={{ bg: `${backgroundColor}.900` }}
-          onClick={(e) => {
-            // important to prevent the click from propogating upwards and triggering the toggle
-            e.stopPropagation();
-            removeYearFromCurrPlan();
-          }}
-        />
-      </Tooltip>
+      <Flex>
+        {displayReqErrors && (
+          <Tooltip label={`There are coreq and/or Prereq errors`} fontSize="md">
+            <IconButton
+              aria-label="There are coreq and/or prereq errors!"
+              variant="ghost"
+              color="primary.red.main"
+              icon={<WarningIcon />}
+              _hover={{ bg: `white` }}
+              _active={{ }}
+              onClick={() => {
+                // open modal
+                console.log("open modal");
+              }}
+            />
+          </Tooltip>
+        )}
+        <Tooltip label={`Delete year ${year.year}?`} fontSize="md">
+          <IconButton
+            aria-label="Delete course"
+            variant="ghost"
+            color="white"
+            icon={<DeleteIcon />}
+            marginLeft="auto"
+            marginRight="sm"
+            _hover={{ bg: "white", color: "primary.red.main" }}
+            _active={{ bg: `${backgroundColor}.900` }}
+            onClick={(e) => {
+              // important to prevent the click from propogating upwards and triggering the toggle
+              e.stopPropagation();
+              removeYearFromCurrPlan();
+            }}
+          />
+        </Tooltip>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -2,8 +2,6 @@ import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
 import {
   Flex,
   Grid,
-  // GridItem,
-  // GridItemProps,
   IconButton,
   Text,
   Tooltip,
@@ -179,7 +177,7 @@ const YearHeader: React.FC<YearHeaderProps> = ({
       </Flex>
       <Flex>
         {displayReqErrors && (
-          <Tooltip label={`There are coreq and/or Prereq errors`} fontSize="md">
+          <Tooltip label={`There are coreq and/or prereq errors`} fontSize="md">
             <IconButton
               aria-label="There are coreq and/or prereq errors!"
               variant="ghost"

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -1,13 +1,14 @@
-import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
+import { DeleteIcon } from "@chakra-ui/icons";
 import { Flex } from "@chakra-ui/react";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import {
   courseToString,
   INEUPrereqError,
-  ScheduleCourse2
+  ScheduleCourse2,
 } from "@graduate/common";
 import { forwardRef, useState } from "react";
+import { ReqErrorModal } from "../Plan/ReqErrorModal";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
@@ -169,11 +170,7 @@ export const ScheduleCourse = forwardRef<
             }}
             _active={{ background: "primary.red.900" }}
           >
-            <WarningIcon
-              color="primary.red.main"
-              transition="color 0.1s ease"
-              // Open Modal here
-            />
+            <ReqErrorModal />
           </Flex>
         )}
         {isEditable && hovered && (

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -170,7 +170,7 @@ export const ScheduleCourse = forwardRef<
             }}
             _active={{ background: "primary.red.900" }}
           >
-            <ReqErrorModal course={} coReqErr={coReqErr} preReqErr={preReqErr} />
+            <ReqErrorModal course={scheduleCourse} coReqErr={coReqErr} preReqErr={preReqErr} />
           </Flex>
         )}
         {isEditable && hovered && (

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -170,7 +170,7 @@ export const ScheduleCourse = forwardRef<
             }}
             _active={{ background: "primary.red.900" }}
           >
-            <ReqErrorModal />
+            <ReqErrorModal coReqErr={coReqErr} preReqErr={preReqErr} />
           </Flex>
         )}
         {isEditable && hovered && (

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -102,7 +102,7 @@ export const ScheduleCourse = forwardRef<
           display: "flex",
           borderRadius: "5px",
           fontSize: "14px",
-          alignItems: "center",
+          alignItems: "stretch",
           flex: scheduleCourse.classId === "Experiential Learning" ? 1 : 0,
           marginBottom: "6px",
           transition: "transform 0.15s ease",
@@ -155,52 +155,54 @@ export const ScheduleCourse = forwardRef<
             </span>
           </p>
         </div>
-        {(coReqErr != undefined || preReqErr != undefined) && (
-          <ReqErrorModal
-            course={scheduleCourse}
-            coReqErr={coReqErr}
-            preReqErr={preReqErr}
-          />
-        )}
-        {isEditable && hovered && (
-          <Flex
-            width="32px"
-            alignSelf="stretch"
-            flexShrink={0}
-            alignItems="center"
-            justifyContent="center"
-            borderRadius="0px 5px 5px 0px"
-            transition="background 0.15s ease"
-            _hover={{
-              background: "primary.blue.dark.main",
-              fill: "white",
-              svg: {
-                color: "white",
-              },
-            }}
-            _active={{
-              background: "primary.blue.dark.900",
-            }}
-            onClick={
-              removeCourse
-                ? () => {
-                    removeCourse(scheduleCourse);
-                  }
-                : undefined
-            }
-          >
-            <DeleteIcon
-              color="primary.blue.dark.300"
-              transition="color 0.1s ease"
+        <Flex>
+          {(coReqErr != undefined || preReqErr != undefined) && (
+            <ReqErrorModal
+              course={scheduleCourse}
+              coReqErr={coReqErr}
+              preReqErr={preReqErr}
             />
-          </Flex>
-        )}
-        {(isOverlay || (isEditable && !hovered)) && (
-          // This is a spacer to take up the same amount of space as the delete button
-          // so we don't have the text of the course shifting around when it's hovered
-          // or dragged.
-          <div style={{ width: "32px", height: "32px", flexShrink: 0 }}></div>
-        )}
+          )}
+          {isEditable && hovered && (
+            <Flex
+              width="32px"
+              alignSelf="stretch"
+              flexShrink={0}
+              alignItems="center"
+              justifyContent="center"
+              borderRadius="0px 5px 5px 0px"
+              transition="background 0.15s ease"
+              _hover={{
+                background: "primary.blue.dark.main",
+                fill: "white",
+                svg: {
+                  color: "white",
+                },
+              }}
+              _active={{
+                background: "primary.blue.dark.900",
+              }}
+              onClick={
+                removeCourse
+                  ? () => {
+                      removeCourse(scheduleCourse);
+                    }
+                  : undefined
+              }
+            >
+              <DeleteIcon
+                color="primary.blue.dark.300"
+                transition="color 0.1s ease"
+              />
+            </Flex>
+          )}
+          {(isOverlay || (isEditable && !hovered)) && (
+            // This is a spacer to take up the same amount of space as the delete button
+            // so we don't have the text of the course shifting around when it's hovered
+            // or dragged.
+            <div style={{ width: "32px", height: "32px", flexShrink: 0 }}></div>
+          )}
+        </Flex>
       </div>
     );
   }

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -12,8 +12,8 @@ import { ReqErrorModal } from "../Plan/ReqErrorModal";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
-  coReqErr: INEUReqError | undefined;
-  preReqErr: INEUReqError | undefined;
+  coReqErr?: INEUReqError;
+  preReqErr?: INEUReqError;
 
   /** Function to remove the course from whatever the schedule it is part of. */
   removeCourse?: (course: ScheduleCourse2<unknown>) => void;
@@ -25,10 +25,10 @@ interface DraggableScheduleCourseProps {
 export const DraggableScheduleCourse: React.FC<
   DraggableScheduleCourseProps
 > = ({
-  coReqErr,
-  preReqErr,
   scheduleCourse,
   removeCourse,
+  preReqErr = undefined,
+  coReqErr = undefined,
   isEditable = false,
   isFromSidebar = false,
   isDisabled = false,
@@ -61,8 +61,8 @@ export const DraggableScheduleCourse: React.FC<
 };
 
 interface ScheduleCourseProps extends DraggableScheduleCourseProps {
-  coReqErr: INEUReqError | undefined;
-  preReqErr: INEUReqError | undefined;
+  coReqErr?: INEUReqError;
+  preReqErr?: INEUReqError;
   isDragging?: boolean;
   listeners?: any;
   attributes?: any;
@@ -78,8 +78,8 @@ export const ScheduleCourse = forwardRef<
 >(
   (
     {
-      coReqErr,
-      preReqErr,
+      coReqErr = undefined,
+      preReqErr = undefined,
       scheduleCourse,
       removeCourse,
       isEditable = false,

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -1,6 +1,10 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { forwardRef, useState } from "react";
-import { INEUPrereqError, ScheduleCourse2 } from "@graduate/common";
+import {
+  courseToString,
+  INEUPrereqError,
+  ScheduleCourse2,
+} from "@graduate/common";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { DeleteIcon } from "@chakra-ui/icons";
@@ -144,12 +148,17 @@ export const ScheduleCourse = forwardRef<
             ></path>
           </svg>
           <p style={{ fontWeight: "bold" }}>
-            {scheduleCourse.classId}{" "}
+            {`${courseToString(scheduleCourse)} `}
             <span style={{ marginLeft: "2px", fontWeight: "normal" }}>
               {scheduleCourse.name}
             </span>
           </p>
         </div>
+        {(coReqErr != undefined || preReqErr != undefined) && (
+          <Text fontSize="sm" background="red">
+            error
+          </Text>
+        )}
         {isEditable && hovered && (
           <Flex
             width="32px"
@@ -177,11 +186,6 @@ export const ScheduleCourse = forwardRef<
                 : undefined
             }
           >
-            {(coReqErr != undefined || preReqErr != undefined) && (
-              <Text fontSize="sm" background="red">
-                error
-              </Text>
-            )}
             <DeleteIcon
               color="primary.blue.dark.300"
               transition="color 0.1s ease"

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -1,12 +1,14 @@
-import { Flex } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { forwardRef, useState } from "react";
-import { ScheduleCourse2 } from "@graduate/common";
+import { INEUPrereqError, ScheduleCourse2 } from "@graduate/common";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { DeleteIcon } from "@chakra-ui/icons";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
+  coReqErr: INEUPrereqError | undefined;
+  preReqErr: INEUPrereqError | undefined;
 
   /** Function to remove the course from whatever the schedule it is part of. */
   removeCourse?: (course: ScheduleCourse2<unknown>) => void;
@@ -18,6 +20,8 @@ interface DraggableScheduleCourseProps {
 export const DraggableScheduleCourse: React.FC<
   DraggableScheduleCourseProps
 > = ({
+  coReqErr,
+  preReqErr,
   scheduleCourse,
   removeCourse,
   isEditable = false,
@@ -36,6 +40,8 @@ export const DraggableScheduleCourse: React.FC<
 
   return (
     <ScheduleCourse
+      coReqErr={coReqErr}
+      preReqErr={preReqErr}
       ref={setNodeRef}
       scheduleCourse={scheduleCourse}
       removeCourse={removeCourse}
@@ -50,6 +56,8 @@ export const DraggableScheduleCourse: React.FC<
 };
 
 interface ScheduleCourseProps extends DraggableScheduleCourseProps {
+  coReqErr: INEUPrereqError | undefined;
+  preReqErr: INEUPrereqError | undefined;
   isDragging?: boolean;
   listeners?: any;
   attributes?: any;
@@ -65,6 +73,8 @@ export const ScheduleCourse = forwardRef<
 >(
   (
     {
+      coReqErr,
+      preReqErr,
       scheduleCourse,
       removeCourse,
       isEditable = false,
@@ -167,6 +177,11 @@ export const ScheduleCourse = forwardRef<
                 : undefined
             }
           >
+            {(coReqErr != undefined || preReqErr != undefined) && (
+              <Text fontSize="sm" background="red">
+                error
+              </Text>
+            )}
             <DeleteIcon
               color="primary.blue.dark.300"
               transition="color 0.1s ease"

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -1,13 +1,13 @@
-import { Flex, Text } from "@chakra-ui/react";
-import { forwardRef, useState } from "react";
+import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
+import { Flex } from "@chakra-ui/react";
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import {
   courseToString,
   INEUPrereqError,
-  ScheduleCourse2,
+  ScheduleCourse2
 } from "@graduate/common";
-import { useDraggable } from "@dnd-kit/core";
-import { CSS } from "@dnd-kit/utilities";
-import { DeleteIcon } from "@chakra-ui/icons";
+import { forwardRef, useState } from "react";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
@@ -155,9 +155,26 @@ export const ScheduleCourse = forwardRef<
           </p>
         </div>
         {(coReqErr != undefined || preReqErr != undefined) && (
-          <Text fontSize="sm" background="red">
-            error
-          </Text>
+          <Flex
+            width="2rem"
+            alignSelf="stretch"
+            flexShrink={0}
+            alignItems="center"
+            justifyContent="center"
+            transition="background 0.15s ease"
+            _hover={{
+              background: "primary.red.main",
+              fill: "white",
+              svg: { color: "white" },
+            }}
+            _active={{ background: "primary.red.900" }}
+          >
+            <WarningIcon
+              color="primary.red.main"
+              transition="color 0.1s ease"
+              // Open Modal here
+            />
+          </Flex>
         )}
         {isEditable && hovered && (
           <Flex

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -4,7 +4,7 @@ import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import {
   courseToString,
-  INEUPrereqError,
+  INEUReqError,
   ScheduleCourse2,
 } from "@graduate/common";
 import { forwardRef, useState } from "react";
@@ -12,8 +12,8 @@ import { ReqErrorModal } from "../Plan/ReqErrorModal";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
-  coReqErr: INEUPrereqError | undefined;
-  preReqErr: INEUPrereqError | undefined;
+  coReqErr: INEUReqError | undefined;
+  preReqErr: INEUReqError | undefined;
 
   /** Function to remove the course from whatever the schedule it is part of. */
   removeCourse?: (course: ScheduleCourse2<unknown>) => void;
@@ -61,8 +61,8 @@ export const DraggableScheduleCourse: React.FC<
 };
 
 interface ScheduleCourseProps extends DraggableScheduleCourseProps {
-  coReqErr: INEUPrereqError | undefined;
-  preReqErr: INEUPrereqError | undefined;
+  coReqErr: INEUReqError | undefined;
+  preReqErr: INEUReqError | undefined;
   isDragging?: boolean;
   listeners?: any;
   attributes?: any;

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   courseToString,
   INEUPrereqError,
-  ScheduleCourse2
+  ScheduleCourse2,
 } from "@graduate/common";
 import { forwardRef, useState } from "react";
 import { ReqErrorModal } from "../Plan/ReqErrorModal";
@@ -156,22 +156,11 @@ export const ScheduleCourse = forwardRef<
           </p>
         </div>
         {(coReqErr != undefined || preReqErr != undefined) && (
-          <Flex
-            width="2rem"
-            alignSelf="stretch"
-            flexShrink={0}
-            alignItems="center"
-            justifyContent="center"
-            transition="background 0.15s ease"
-            _hover={{
-              background: "primary.red.main",
-              fill: "white",
-              svg: { color: "white" },
-            }}
-            _active={{ background: "primary.red.900" }}
-          >
-            <ReqErrorModal course={scheduleCourse} coReqErr={coReqErr} preReqErr={preReqErr} />
-          </Flex>
+          <ReqErrorModal
+            course={scheduleCourse}
+            coReqErr={coReqErr}
+            preReqErr={preReqErr}
+          />
         )}
         {isEditable && hovered && (
           <Flex

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -5,7 +5,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   courseToString,
   INEUPrereqError,
-  ScheduleCourse2,
+  ScheduleCourse2
 } from "@graduate/common";
 import { forwardRef, useState } from "react";
 import { ReqErrorModal } from "../Plan/ReqErrorModal";
@@ -170,7 +170,7 @@ export const ScheduleCourse = forwardRef<
             }}
             _active={{ background: "primary.red.900" }}
           >
-            <ReqErrorModal coReqErr={coReqErr} preReqErr={preReqErr} />
+            <ReqErrorModal course={} coReqErr={coReqErr} preReqErr={preReqErr} />
           </Flex>
         )}
         {isEditable && hovered && (

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -6,7 +6,7 @@ import {
   DragOverlay,
   DragStartEvent,
   pointerWithin,
-  rectIntersection
+  rectIntersection,
 } from "@dnd-kit/core";
 import { API } from "@graduate/api-client";
 import { CoReqWarnings, PlanModel, PreReqWarnings } from "@graduate/common";
@@ -24,7 +24,7 @@ import {
   Plan,
   PlanDropdown,
   ScheduleCourse,
-  Sidebar
+  Sidebar,
 } from "../components";
 import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
 import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
@@ -34,12 +34,12 @@ import {
   logger,
   logout,
   updatePlanForStudent,
-  updatePlanOnDragEnd
+  updatePlanOnDragEnd,
 } from "../utils";
 import { getMajor2Example } from "../utils/convertMajor";
 import {
   getCoReqWarnings,
-  getPreReqWarnings
+  getPreReqWarnings,
 } from "../utils/plan/preAndCoReqCheck";
 
 const DEMO_MAJOR = getMajor2Example();
@@ -91,7 +91,6 @@ const HomePage: NextPage = () => {
       }
     }
   }, [student, selectedPlanId, setSelectedPlanId]);
-
 
   /**
    * Handle errors from useStudentWithPlans.
@@ -207,7 +206,6 @@ const HomePage: NextPage = () => {
               setSelectedPlanId={setSelectedPlanId}
               plans={student.plans}
             />
-            <ReqErrorModal />
             <AddPlanModal setSelectedPlanId={setSelectedPlanId} />
             {selectedPlan && <EditPlanModal plan={selectedPlan} />}
             {selectedPlan && (

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -132,15 +132,14 @@ const HomePage: NextPage = () => {
     let updatedPlan: PlanModel<string>;
     try {
       updatedPlan = updatePlanOnDragEnd(selectedPlan, active, over);
-      // TODO: Update states for coreq and prereq
-      setPreReqWarnings(getPreReqWarnings(updatedPlan.schedule))
-      setCoReqWarnings(getCoReqWarnings(updatedPlan.schedule))
     } catch (err) {
       // update failed, either due to some logical issue or explicitely thrown error
       logger.debug("updatePlanOnDragEnd", err);
       return;
     }
-
+    
+    setPreReqWarnings(getPreReqWarnings(updatedPlan.schedule));
+    setCoReqWarnings(getCoReqWarnings(updatedPlan.schedule));
     mutateStudentWithUpdatedPlan(updatedPlan);
   };
 

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -6,7 +6,7 @@ import {
   DragOverlay,
   DragStartEvent,
   pointerWithin,
-  rectIntersection,
+  rectIntersection
 } from "@dnd-kit/core";
 import { API } from "@graduate/api-client";
 import { CoReqWarnings, PlanModel, PreReqWarnings } from "@graduate/common";
@@ -24,7 +24,7 @@ import {
   Plan,
   PlanDropdown,
   ScheduleCourse,
-  Sidebar,
+  Sidebar
 } from "../components";
 import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
 import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
@@ -34,12 +34,12 @@ import {
   logger,
   logout,
   updatePlanForStudent,
-  updatePlanOnDragEnd,
+  updatePlanOnDragEnd
 } from "../utils";
 import { getMajor2Example } from "../utils/convertMajor";
 import {
-  getPreReqWarnings,
   getCoReqWarnings,
+  getPreReqWarnings
 } from "../utils/plan/preAndCoReqCheck";
 
 const DEMO_MAJOR = getMajor2Example();

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -9,7 +9,7 @@ import {
   rectIntersection
 } from "@dnd-kit/core";
 import { API } from "@graduate/api-client";
-import { PlanModel } from "@graduate/common";
+import { CoReqWarnings, PlanModel, PreReqWarnings } from "@graduate/common";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { PropsWithChildren, useEffect, useState } from "react";
@@ -29,6 +29,7 @@ import {
   updatePlanOnDragEnd
 } from "../utils";
 import { getMajor2Example } from "../utils/convertMajor";
+import { getPreReqWarnings, getCoReqWarnings } from "../utils/plan/preAndCoReqCheck";
 
 const DEMO_MAJOR = getMajor2Example();
 
@@ -58,6 +59,9 @@ const HomePage: NextPage = () => {
   >();
 
   const [activeCourse, setActiveCourse] = useState(null);
+
+  const [coReqWarnings, setCoReqWarnings] = useState<CoReqWarnings | undefined>(undefined)
+  const [preReqWarnings, setPreReqWarnings] = useState<PreReqWarnings | undefined>(undefined)
 
   useEffect(() => {
     // once the student is fetched, set the selected plan id to the primary plan id
@@ -128,6 +132,9 @@ const HomePage: NextPage = () => {
     let updatedPlan: PlanModel<string>;
     try {
       updatedPlan = updatePlanOnDragEnd(selectedPlan, active, over);
+      // TODO: Update states for coreq and prereq
+      setPreReqWarnings(getPreReqWarnings(updatedPlan.schedule))
+      setCoReqWarnings(getCoReqWarnings(updatedPlan.schedule))
     } catch (err) {
       // update failed, either due to some logical issue or explicitely thrown error
       logger.debug("updatePlanOnDragEnd", err);

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -6,7 +6,7 @@ import {
   DragOverlay,
   DragStartEvent,
   pointerWithin,
-  rectIntersection
+  rectIntersection,
 } from "@dnd-kit/core";
 import { API } from "@graduate/api-client";
 import { CoReqWarnings, PlanModel, PreReqWarnings } from "@graduate/common";
@@ -14,22 +14,33 @@ import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { PropsWithChildren, useEffect, useState } from "react";
 import {
-  AddPlanModal, AddYearButton, DeletePlanModal, EditPlanModal, HeaderContainer,
+  AddPlanModal,
+  AddYearButton,
+  DeletePlanModal,
+  EditPlanModal,
+  HeaderContainer,
   LoadingPage,
   Logo,
-  Plan, PlanDropdown,
-  ScheduleCourse, Sidebar
+  Plan,
+  PlanDropdown,
+  ScheduleCourse,
+  Sidebar,
 } from "../components";
 import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
 import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
 import {
-  cleanDndIdsFromPlan, handleApiClientError, logger,
+  cleanDndIdsFromPlan,
+  handleApiClientError,
+  logger,
   logout,
   updatePlanForStudent,
-  updatePlanOnDragEnd
+  updatePlanOnDragEnd,
 } from "../utils";
 import { getMajor2Example } from "../utils/convertMajor";
-import { getPreReqWarnings, getCoReqWarnings } from "../utils/plan/preAndCoReqCheck";
+import {
+  getPreReqWarnings,
+  getCoReqWarnings,
+} from "../utils/plan/preAndCoReqCheck";
 
 const DEMO_MAJOR = getMajor2Example();
 
@@ -60,13 +71,24 @@ const HomePage: NextPage = () => {
 
   const [activeCourse, setActiveCourse] = useState(null);
 
-  const [coReqWarnings, setCoReqWarnings] = useState<CoReqWarnings | undefined>(undefined)
-  const [preReqWarnings, setPreReqWarnings] = useState<PreReqWarnings | undefined>(undefined)
+  const [coReqWarnings, setCoReqWarnings] = useState<CoReqWarnings | undefined>(
+    undefined
+  );
+  const [preReqWarnings, setPreReqWarnings] = useState<
+    PreReqWarnings | undefined
+  >(undefined);
 
   useEffect(() => {
     // once the student is fetched, set the selected plan id to the primary plan id
     if (student && selectedPlanId === undefined) {
       setSelectedPlanId(student.primaryPlanId);
+    }
+    if (student) {
+      const plan = student.plans.find((plan) => plan.id === selectedPlanId);
+      if (plan) {
+        setPreReqWarnings(getPreReqWarnings(plan.schedule));
+        setCoReqWarnings(getCoReqWarnings(plan.schedule));
+      }
     }
   }, [student, selectedPlanId, setSelectedPlanId]);
 
@@ -137,7 +159,7 @@ const HomePage: NextPage = () => {
       logger.debug("updatePlanOnDragEnd", err);
       return;
     }
-    
+
     setPreReqWarnings(getPreReqWarnings(updatedPlan.schedule));
     setCoReqWarnings(getCoReqWarnings(updatedPlan.schedule));
     mutateStudentWithUpdatedPlan(updatedPlan);
@@ -199,6 +221,8 @@ const HomePage: NextPage = () => {
             <>
               <Plan
                 plan={selectedPlan}
+                coReqErr={coReqWarnings}
+                preReqErr={preReqWarnings}
                 mutateStudentWithUpdatedPlan={mutateStudentWithUpdatedPlan}
               />
               <Flex mt="sm">
@@ -217,6 +241,8 @@ const HomePage: NextPage = () => {
             isDisabled={false}
             scheduleCourse={activeCourse}
             isOverlay={true}
+            coReqErr={undefined}
+            preReqErr={undefined}
           />
         ) : null}
       </DragOverlay>

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -101,24 +101,23 @@ const HomePage: NextPage = () => {
 
   const selectedPlan = student.plans.find((plan) => selectedPlanId === plan.id);
 
-  useEffect(()=> {
-
+  useEffect(() => {
     if (selectedPlan) {
       for (const elem of selectedPlan.schedule.years) {
-          console.log(getCoReqWarnings(elem.fall))
-          console.log(getCoReqWarnings(elem.spring))
-          console.log(getCoReqWarnings(elem.summer2))
-          console.log(getCoReqWarnings(elem.summer1))
+        console.log(getCoReqWarnings(elem.fall));
+        console.log(getCoReqWarnings(elem.spring));
+        console.log(getCoReqWarnings(elem.summer2));
+        console.log(getCoReqWarnings(elem.summer1));
       }
-      
-      for (const elem of selectedPlan.schedule.years) {
-          console.log(getCoReqWarnings(elem.fall))
-          console.log(getCoReqWarnings(elem.spring))
-          console.log(getCoReqWarnings(elem.summer2))
-          console.log(getCoReqWarnings(elem.summer1))
-      }
-  })
 
+      for (const elem of selectedPlan.schedule.years) {
+        console.log(getCoReqWarnings(elem.fall));
+        console.log(getCoReqWarnings(elem.spring));
+        console.log(getCoReqWarnings(elem.summer2));
+        console.log(getCoReqWarnings(elem.summer1));
+      }
+    }
+  });
 
   /**
    * When a course is dragged and dropped onto a semester

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -36,7 +36,11 @@ import { useRouter } from "next/router";
 import { Box, Button, Flex } from "@chakra-ui/react";
 import React, { PropsWithChildren, useEffect, useState } from "react";
 import { getMajor2Example } from "../utils/convertMajor";
-import { getCoReqWarnings } from "../utils/plan/preAndCoReqCheck";
+import {
+  getCoReqWarnings,
+  getPreReqWarningSem,
+} from "../utils/plan/preAndCoReqCheck";
+import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
 
 const DEMO_MAJOR = getMajor2Example();
 
@@ -100,24 +104,6 @@ const HomePage: NextPage = () => {
   }
 
   const selectedPlan = student.plans.find((plan) => selectedPlanId === plan.id);
-
-  useEffect(() => {
-    if (selectedPlan) {
-      for (const elem of selectedPlan.schedule.years) {
-        console.log(getCoReqWarnings(elem.fall));
-        console.log(getCoReqWarnings(elem.spring));
-        console.log(getCoReqWarnings(elem.summer2));
-        console.log(getCoReqWarnings(elem.summer1));
-      }
-
-      for (const elem of selectedPlan.schedule.years) {
-        console.log(getCoReqWarnings(elem.fall));
-        console.log(getCoReqWarnings(elem.spring));
-        console.log(getCoReqWarnings(elem.summer2));
-        console.log(getCoReqWarnings(elem.summer1));
-      }
-    }
-  });
 
   /**
    * When a course is dragged and dropped onto a semester
@@ -204,6 +190,7 @@ const HomePage: NextPage = () => {
               setSelectedPlanId={setSelectedPlanId}
               plans={student.plans}
             />
+            <ReqErrorModal />
             <AddPlanModal setSelectedPlanId={setSelectedPlanId} />
             {selectedPlan && <EditPlanModal plan={selectedPlan} />}
             {selectedPlan && (

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -36,6 +36,7 @@ import { useRouter } from "next/router";
 import { Box, Button, Flex } from "@chakra-ui/react";
 import React, { PropsWithChildren, useEffect, useState } from "react";
 import { getMajor2Example } from "../utils/convertMajor";
+import { getCoReqWarnings } from "../utils/plan/preAndCoReqCheck";
 
 const DEMO_MAJOR = getMajor2Example();
 
@@ -99,6 +100,25 @@ const HomePage: NextPage = () => {
   }
 
   const selectedPlan = student.plans.find((plan) => selectedPlanId === plan.id);
+
+  useEffect(()=> {
+
+    if (selectedPlan) {
+      for (const elem of selectedPlan.schedule.years) {
+          console.log(getCoReqWarnings(elem.fall))
+          console.log(getCoReqWarnings(elem.spring))
+          console.log(getCoReqWarnings(elem.summer2))
+          console.log(getCoReqWarnings(elem.summer1))
+      }
+      
+      for (const elem of selectedPlan.schedule.years) {
+          console.log(getCoReqWarnings(elem.fall))
+          console.log(getCoReqWarnings(elem.spring))
+          console.log(getCoReqWarnings(elem.summer2))
+          console.log(getCoReqWarnings(elem.summer1))
+      }
+  })
+
 
   /**
    * When a course is dragged and dropped onto a semester

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -26,7 +26,6 @@ import {
   ScheduleCourse,
   Sidebar,
 } from "../components";
-import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
 import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
 import {
   cleanDndIdsFromPlan,

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -88,16 +88,10 @@ const HomePage: NextPage = () => {
       if (plan) {
         setPreReqWarnings(getPreReqWarnings(plan.schedule));
         setCoReqWarnings(getCoReqWarnings(plan.schedule));
-        console.log(plan.schedule)
       }
     }
   }, [student, selectedPlanId, setSelectedPlanId]);
 
-  useEffect(() => {
-    console.log(preReqWarnings);
-    console.log(coReqWarnings);
-  }, [preReqWarnings, coReqWarnings])
-  
 
   /**
    * Handle errors from useStudentWithPlans.

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -1,46 +1,34 @@
-import { NextPage } from "next";
+import { Box, Button, Flex } from "@chakra-ui/react";
 import {
-  AddPlanModal,
-  EditPlanModal,
-  DeletePlanModal,
-  HeaderContainer,
-  LoadingPage,
-  Logo,
-  Plan,
-  Sidebar,
-  PlanDropdown,
-  ScheduleCourse,
-  AddYearButton,
-} from "../components";
-import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
-import {
+  CollisionDetection,
   DndContext,
   DragEndEvent,
   DragOverlay,
   DragStartEvent,
   pointerWithin,
-  rectIntersection,
-  CollisionDetection,
+  rectIntersection
 } from "@dnd-kit/core";
-import {
-  cleanDndIdsFromPlan,
-  logger,
-  logout,
-  updatePlanForStudent,
-  updatePlanOnDragEnd,
-  handleApiClientError,
-} from "../utils";
 import { API } from "@graduate/api-client";
 import { PlanModel } from "@graduate/common";
+import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { Box, Button, Flex } from "@chakra-ui/react";
-import React, { PropsWithChildren, useEffect, useState } from "react";
-import { getMajor2Example } from "../utils/convertMajor";
+import { PropsWithChildren, useEffect, useState } from "react";
 import {
-  getCoReqWarnings,
-  getPreReqWarningSem,
-} from "../utils/plan/preAndCoReqCheck";
+  AddPlanModal, AddYearButton, DeletePlanModal, EditPlanModal, HeaderContainer,
+  LoadingPage,
+  Logo,
+  Plan, PlanDropdown,
+  ScheduleCourse, Sidebar
+} from "../components";
 import { ReqErrorModal } from "../components/Plan/ReqErrorModal";
+import { fetchStudentAndPrepareForDnd, useStudentWithPlans } from "../hooks";
+import {
+  cleanDndIdsFromPlan, handleApiClientError, logger,
+  logout,
+  updatePlanForStudent,
+  updatePlanOnDragEnd
+} from "../utils";
+import { getMajor2Example } from "../utils/convertMajor";
 
 const DEMO_MAJOR = getMajor2Example();
 

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -88,9 +88,16 @@ const HomePage: NextPage = () => {
       if (plan) {
         setPreReqWarnings(getPreReqWarnings(plan.schedule));
         setCoReqWarnings(getCoReqWarnings(plan.schedule));
+        console.log(plan.schedule)
       }
     }
   }, [student, selectedPlanId, setSelectedPlanId]);
+
+  useEffect(() => {
+    console.log(preReqWarnings);
+    console.log(coReqWarnings);
+  }, [preReqWarnings, coReqWarnings])
+  
 
   /**
    * Handle errors from useStudentWithPlans.

--- a/packages/frontend-v2/utils/course/getCourseCoreqs.ts
+++ b/packages/frontend-v2/utils/course/getCourseCoreqs.ts
@@ -2,7 +2,7 @@ import { SearchAPI } from "@graduate/api-client";
 import {
   ScheduleCourse2,
   INEUPrereq,
-  INEUPrereqCourse,
+  INEUReqCourse,
 } from "@graduate/common";
 
 /** Get all the required(ANDs only) coreqs for a given course. */
@@ -36,6 +36,6 @@ export async function getRequiredCourseCoreqs(
 }
 
 /** Type Guard: Asserts that the given val is a SearchNEU pre-req course. */
-const isINEUPrereqCourse = (val: INEUPrereq): val is INEUPrereqCourse => {
-  return !!(val as INEUPrereqCourse);
+const isINEUPrereqCourse = (val: INEUPrereq): val is INEUReqCourse => {
+  return !!(val as INEUReqCourse);
 };

--- a/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
+++ b/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
@@ -1,19 +1,10 @@
 import {
-  courseError,
-  INEUAndPrereq,
-  INEUOrPrereq,
-  INEUPrereq,
-  INEUPrereqCourse,
-  INEUPrereqError,
-  preReqWarnings,
-  Schedule2,
-  ScheduleTerm2,
-  courseToString,
+  CourseError, INEUAndPrereq, INEUOrPrereq, INEUPrereq, INEUPrereqCourse, INEUPrereqError, PreReqWarnings, Schedule2, ScheduleTerm2, courseToString
 } from "@graduate/common";
 
 export const getCoReqWarnings = (term: ScheduleTerm2<unknown>) => {
   const seen: Set<string> = new Set();
-  const coReqErrors: courseError = {};
+  const coReqErrors: CourseError = {}
   for (const course of term.classes) {
     seen.add(courseToString(course));
   }
@@ -26,8 +17,8 @@ export const getCoReqWarnings = (term: ScheduleTerm2<unknown>) => {
   return coReqErrors;
 };
 
-export const getPreReqWarnings = (schedule: Schedule2<unknown>) => {
-  const preReqErrors: preReqWarnings = {};
+export const getPreReqWarnings = (schedule: Schedule2<unknown>): PreReqWarnings => {
+  const preReqErrors: PreReqWarnings = {}
   const seen: Set<string> = new Set();
   for (const year of schedule.years) {
     preReqErrors[year.year] = {
@@ -44,11 +35,8 @@ export const getPreReqWarnings = (schedule: Schedule2<unknown>) => {
   return preReqErrors;
 };
 
-export const getPreReqWarningSem = (
-  term: ScheduleTerm2<unknown>,
-  seen: Set<string>
-) => {
-  const preReqs: courseError = {};
+export const getPreReqWarningSem = (term: ScheduleTerm2<unknown>, seen: Set<string>): CourseError => {
+  const preReqs: CourseError = {}
   for (const course of term.classes) {
     // Course has prereqs
     if (course.prereqs && course.prereqs.values.length !== 0) {

--- a/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
+++ b/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
@@ -1,11 +1,11 @@
 import {
   CoReqWarnings,
   courseToString,
-  INEUAndPrereq,
-  INEUOrPrereq,
+  INEUAndReq,
+  INEUOrReq,
   INEUPrereq,
-  INEUPrereqCourse,
-  INEUPrereqError,
+  INEUReqCourse,
+  INEUReqError,
   PreReqWarnings,
   Schedule2,
   ScheduleTerm2,
@@ -80,9 +80,9 @@ export const getPreReqWarningSem = (
 const getReqErrors = (
   reqs: INEUPrereq,
   seen: Set<string>
-): INEUPrereqError | undefined => {
+): INEUReqError | undefined => {
   if (isSingleCourse(reqs)) {
-    const singleReq = reqs as INEUPrereqCourse;
+    const singleReq = reqs as INEUReqCourse;
     return seen.has(courseToString(singleReq))
       ? undefined
       : {
@@ -91,7 +91,7 @@ const getReqErrors = (
           classId: singleReq.classId,
         };
   } else if (isAndCourse(reqs)) {
-    const andReq = reqs as INEUAndPrereq;
+    const andReq = reqs as INEUAndReq;
     const required = andReq.values
       .map((req) => getReqErrors(req, seen))
       .filter(isError);
@@ -101,7 +101,7 @@ const getReqErrors = (
       missing: required,
     };
   } else if (isOrCourse(reqs)) {
-    const orReq = reqs as INEUOrPrereq;
+    const orReq = reqs as INEUOrReq;
     const missing = orReq.values.map((req) => getReqErrors(req, seen));
     // There is a course that fulfils this or case
     if (missing.includes(undefined)) {
@@ -116,20 +116,20 @@ const getReqErrors = (
   }
 };
 
-const isSingleCourse = (course: INEUPrereq): course is INEUPrereqCourse => {
-  return (course as INEUPrereqCourse).subject !== undefined;
+const isSingleCourse = (course: INEUPrereq): course is INEUReqCourse => {
+  return (course as INEUReqCourse).subject !== undefined;
 };
 
-const isAndCourse = (course: INEUPrereq): course is INEUAndPrereq => {
-  return (course as INEUAndPrereq).type === "and";
+const isAndCourse = (course: INEUPrereq): course is INEUAndReq => {
+  return (course as INEUAndReq).type === "and";
 };
 
-const isOrCourse = (course: INEUPrereq): course is INEUOrPrereq => {
-  return (course as INEUOrPrereq).type === "or";
+const isOrCourse = (course: INEUPrereq): course is INEUOrReq => {
+  return (course as INEUOrReq).type === "or";
 };
 
 const isError = (
-  error: INEUPrereqError | undefined
-): error is INEUPrereqError => {
+  error: INEUReqError | undefined
+): error is INEUReqError => {
   return !!error;
 };

--- a/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
+++ b/packages/frontend-v2/utils/plan/preAndCoReqCheck.ts
@@ -1,8 +1,20 @@
 import {
-  CoReqWarnings, courseToString, INEUAndPrereq, INEUOrPrereq, INEUPrereq, INEUPrereqCourse, INEUPrereqError, PreReqWarnings, Schedule2, ScheduleTerm2, TermError
+  CoReqWarnings,
+  courseToString,
+  INEUAndPrereq,
+  INEUOrPrereq,
+  INEUPrereq,
+  INEUPrereqCourse,
+  INEUPrereqError,
+  PreReqWarnings,
+  Schedule2,
+  ScheduleTerm2,
+  TermError,
 } from "@graduate/common";
 
-export const getCoReqWarnings = (schedule: Schedule2<unknown>): CoReqWarnings => {
+export const getCoReqWarnings = (
+  schedule: Schedule2<unknown>
+): CoReqWarnings => {
   const errors: CoReqWarnings = {
     type: "coreq",
     years: schedule.years.map((year) => ({
@@ -10,15 +22,17 @@ export const getCoReqWarnings = (schedule: Schedule2<unknown>): CoReqWarnings =>
       fall: getCoReqWarningsSem(year.fall),
       spring: getCoReqWarningsSem(year.spring),
       summer1: getCoReqWarningsSem(year.summer1),
-      summer2: getCoReqWarningsSem(year.summer2)
-    }))
-  }
+      summer2: getCoReqWarningsSem(year.summer2),
+    })),
+  };
   return errors;
-}
+};
 
-export const getCoReqWarningsSem = (term: ScheduleTerm2<unknown>): TermError => {
+export const getCoReqWarningsSem = (
+  term: ScheduleTerm2<unknown>
+): TermError => {
   const seen: Set<string> = new Set();
-  const coReqErrors: TermError = {}
+  const coReqErrors: TermError = {};
   for (const course of term.classes) {
     seen.add(courseToString(course));
   }
@@ -29,7 +43,9 @@ export const getCoReqWarningsSem = (term: ScheduleTerm2<unknown>): TermError => 
   return coReqErrors;
 };
 
-export const getPreReqWarnings = (schedule: Schedule2<unknown>): PreReqWarnings => {
+export const getPreReqWarnings = (
+  schedule: Schedule2<unknown>
+): PreReqWarnings => {
   const seen: Set<string> = new Set();
   const preReqErrors: PreReqWarnings = {
     type: "prereq",
@@ -44,8 +60,11 @@ export const getPreReqWarnings = (schedule: Schedule2<unknown>): PreReqWarnings 
   return preReqErrors;
 };
 
-export const getPreReqWarningSem = (term: ScheduleTerm2<unknown>, seen: Set<string>): TermError => {
-  const preReqs: TermError = {}
+export const getPreReqWarningSem = (
+  term: ScheduleTerm2<unknown>,
+  seen: Set<string>
+): TermError => {
+  const preReqs: TermError = {};
   for (const course of term.classes) {
     if (course.prereqs && course.prereqs.values.length !== 0) {
       preReqs[courseToString(course)] = getReqErrors(course.prereqs, seen);

--- a/packages/frontend-v2/utils/theme/components/buttons.ts
+++ b/packages/frontend-v2/utils/theme/components/buttons.ts
@@ -29,7 +29,17 @@ export const Button: ComponentStyleConfig = {
     solid: {
       bg: "primary.red.main",
       color: "white",
-      borderRadius: "0px"
+      borderRadius: "0px",
+    },
+    solidBlue: {
+      bg: "primary.blue.light.main",
+      color: "white",
+      borderRadius: "20px",
+    },
+    solidRed: {
+      bg: "primary.red.main",
+      color: "white",
+      borderRadius: "20px",
     },
   },
   // default size and variant values


### PR DESCRIPTION
# Description

Added coreq/prereq errors for classes. Displays error icon in the year as well as on the specific class. The error Icon on that class opens a modal that tells you specifically what classes you can take to satisfy the error.

Next steps are to add more styling and pagination to the modal.
Another step is also to address the Prop drill down issue, where we would instead use context for the errors.

https://user-images.githubusercontent.com/20482676/200195253-07339502-a79b-414f-8621-19a9c4328bfe.mp4


Closes #454

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests)
Provide instructions so we can reproduce. 

Tested with dragging in coreq/prereq errors and checking if they were giving the correct errors as well as if they went away when we added the correct classes.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
