### PR TITLE
Displaying Major Validation in the Sidebar

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,4 +5,5 @@ export * from "./supported-majors";
 export * from "./course-utils";
 export * from "./api-dtos";
 export * from "./api-response-types";
+export * from "./major2-validation";
 // this file IS included in the build

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -42,7 +42,7 @@ type Solution = {
 type SelectedConcentrationsType = number | string | (number | string)[];
 
 // Error types and constructors
-type MajorValidationError =
+export type MajorValidationError =
   | CourseError
   | AndError
   | OrError
@@ -236,7 +236,7 @@ export class Major2ValidationTracker implements CourseValidationTracker {
 }
 
 // the result of major validation
-type MajorValidationResult = Result<
+export type MajorValidationResult = Result<
   Solution[],
   {
     majorRequirementsError?: MajorValidationError;
@@ -439,7 +439,9 @@ function validateRangeRequirement(
 /**
  * Example: <child 1> <child 2> (CS2810 or CS2800) and (CS2810 or DS3000)
  *
- * Child Solutions: Child 1:
+ * Child Solutions:
+ *
+ * Child 1:
  *
  * - Solution 1: { min: 4, max: 4, sol: [CS2810]}
  * - Solution 2: { min: 4, max: 4, sol: [CS2800]} Child 2:

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -48,7 +48,7 @@ export type MajorValidationError =
   | OrError
   | XOMError
   | SectionError;
-const MajorValidationErrorType = {
+export const MajorValidationErrorType = {
   Course: "COURSE",
   Range: "RANGE",
   And: {

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -99,11 +99,14 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
         major.requirementSections.map((section, index) => {
           let sectionValidationError: MajorValidationError | undefined =
             undefined;
+
+          // Find the error for this sidebar component
           if (validationStatus && validationStatus.type == "Err") {
             if (!validationStatus.err.majorRequirementsError)
               throw new Error("Top level requirement should have an error.");
             if (validationStatus.err.majorRequirementsError.type !== "AND")
               throw new Error("Top level requirement error should be AND.");
+
             const andReq = validationStatus.err.majorRequirementsError?.error;
             if (andReq.type == "AND_UNSAT_CHILD") {
               sectionValidationError = andReq.childErrors.find((error) => {
@@ -113,7 +116,8 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
               andReq.type == "AND_NO_SOLUTION" &&
               andReq.discoveredAtChild == index
             ) {
-              // If a range is invalid, but everything else is okay, it seems to create a No Solution error for that section.
+              // Create a section error so we don't display a check on the section that
+              // caused the "no solution" error.
               sectionValidationError = {
                 type: "SECTION",
                 sectionTitle: section.title,
@@ -121,7 +125,6 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
                 minRequiredChildCount: 0,
                 maxPossibleChildCount: 0,
               };
-              // throw new Error("No solution found to major requirements.")
             }
           }
 

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import { memo, useEffect, useMemo, useState } from "react";
 import SidebarSection from "./SidebarSection";
 import { validateMajor2 } from "@graduate/common";
 import { getAllCoursesFromPlan } from "../../utils/plan/getAllCoursesFromPlan";
+import { getSectionError } from "../../utils/plan/getSectionError";
 
 interface SidebarProps {
   major: Major2;
@@ -97,36 +98,8 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
       </Text>
       {courseData &&
         major.requirementSections.map((section, index) => {
-          let sectionValidationError: MajorValidationError | undefined =
-            undefined;
-
-          // Find the error for this sidebar component
-          if (validationStatus && validationStatus.type == "Err") {
-            if (!validationStatus.err.majorRequirementsError)
-              throw new Error("Top level requirement should have an error.");
-            if (validationStatus.err.majorRequirementsError.type !== "AND")
-              throw new Error("Top level requirement error should be AND.");
-
-            const andReq = validationStatus.err.majorRequirementsError?.error;
-            if (andReq.type == "AND_UNSAT_CHILD") {
-              sectionValidationError = andReq.childErrors.find((error) => {
-                return error.childIndex === index;
-              });
-            } else if (
-              andReq.type == "AND_NO_SOLUTION" &&
-              andReq.discoveredAtChild == index
-            ) {
-              // Create a section error so we don't display a check on the section that
-              // caused the "no solution" error.
-              sectionValidationError = {
-                type: "SECTION",
-                sectionTitle: section.title,
-                childErrors: [],
-                minRequiredChildCount: 0,
-                maxPossibleChildCount: 0,
-              };
-            }
-          }
+          const sectionValidationError: MajorValidationError | undefined =
+            getSectionError(index, validationStatus);
 
           return (
             <SidebarSection

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -42,15 +42,10 @@ const getRequiredCourses = (
 };
 
 const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
-  // console.log(major)
-
-  // let validationStatus: MajorValidationResult | undefined = undefined
   let validationStatus: MajorValidationResult | undefined = useMemo(() => {
     if (selectedPlan) {
       const takenCourses = getAllCoursesFromPlan(selectedPlan);
-      validationStatus = validateMajor2(major, takenCourses, undefined);
-      console.log(validationStatus);
-      return validationStatus;
+      return validateMajor2(major, takenCourses, undefined);
     } else {
       return undefined;
     }

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ const getRequiredCourses = (
 };
 
 const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
-  let validationStatus: MajorValidationResult | undefined = useMemo(() => {
+  const validationStatus: MajorValidationResult | undefined = useMemo(() => {
     if (selectedPlan) {
       const takenCourses = getAllCoursesFromPlan(selectedPlan);
       return validateMajor2(major, takenCourses, undefined);

--- a/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
+++ b/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
@@ -1,5 +1,9 @@
 import { Box, Text } from "@chakra-ui/react";
-import { ScheduleCourse2, Section } from "@graduate/common";
+import {
+  MajorValidationError,
+  ScheduleCourse2,
+  Section,
+} from "@graduate/common";
 import { useState } from "react";
 import SectionRequirement from "./SectionRequirement";
 
@@ -7,21 +11,20 @@ interface SidebarSectionProps {
   section: Section;
   courseData: { [id: string]: ScheduleCourse2<null> };
   dndIdPrefix: string;
+  validationStatus?: MajorValidationError;
 }
 
 const SidebarSection: React.FC<SidebarSectionProps> = ({
   section,
   courseData,
   dndIdPrefix,
+  validationStatus,
 }) => {
   const [opened, setOpened] = useState(false);
+
+  const isComplete = validationStatus == undefined;
   return (
-    <Box
-      backgroundColor="neutral.main"
-      borderTop="1px solid white"
-      cursor="pointer"
-      userSelect="none"
-    >
+    <Box borderTop="1px solid white" cursor="pointer" userSelect="none">
       <Text
         onClick={() => {
           setOpened(!opened);
@@ -30,7 +33,31 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
         fontWeight="bold"
         py="md"
         px="sm"
+        backgroundColor="neutral.main"
+        transition="background-color 0.1s ease"
+        _hover={{
+          backgroundColor: "neutral.900",
+        }}
+        _active={{
+          backgroundColor: "neutral.200",
+        }}
       >
+        {isComplete ? (
+          <span
+            style={{
+              background: "green",
+              color: "white",
+              padding: "3px 6px",
+              width: "26px",
+              marginRight: "6px",
+              borderRadius: "30px",
+            }}
+          >
+            ✓
+          </span>
+        ) : (
+          ""
+        )}
         {section.title}
       </Text>
       <Box

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -177,7 +177,7 @@ const HomePage: NextPage = () => {
       // that feels more intuitive.
       collisionDetection={courseDndCollisisonAlgorithm}
     >
-      <PageLayout>
+      <PageLayout selectedPlan={selectedPlan}>
         <Flex flexDirection="column">
           <Flex alignItems="center" mb="sm">
             <PlanDropdown
@@ -224,11 +224,18 @@ const HomePage: NextPage = () => {
   );
 };
 
+interface PageLayoutProps {
+  selectedPlan: PlanModel<string> | undefined;
+}
+
 /**
  * This will have everything that can be rendered without the student and
  * plans(i.e: header, sidebar, etc)
  */
-const PageLayout: React.FC<PropsWithChildren> = ({ children }) => {
+const PageLayout: React.FC<PropsWithChildren<PageLayoutProps>> = ({
+  children,
+  selectedPlan,
+}) => {
   return (
     <Flex flexDirection="column" height="100vh" overflow="hidden">
       <Header />
@@ -239,7 +246,7 @@ const PageLayout: React.FC<PropsWithChildren> = ({ children }) => {
           width="360px"
           flexShrink={0}
         >
-          <Sidebar major={DEMO_MAJOR} />
+          <Sidebar major={DEMO_MAJOR} selectedPlan={selectedPlan} />
         </Box>
         <Box p="md" overflow="auto" flexGrow={1}>
           {children}

--- a/packages/frontend-v2/utils/plan/getAllCoursesFromPlan.ts
+++ b/packages/frontend-v2/utils/plan/getAllCoursesFromPlan.ts
@@ -9,7 +9,7 @@ const YearSeasons: ("fall" | "spring" | "summer1" | "summer2")[] = [
 
 /**
  * Gets all courses from the given plan. Courses taken multiple times are
- * included in the result.
+ * included in the result multiple times.
  *
  * @param   plan The plan to pull courses from.
  * @returns      All courses in the plan.

--- a/packages/frontend-v2/utils/plan/getAllCoursesFromPlan.ts
+++ b/packages/frontend-v2/utils/plan/getAllCoursesFromPlan.ts
@@ -1,0 +1,29 @@
+import { PlanModel, ScheduleCourse2 } from "@graduate/common";
+
+const YearSeasons: ("fall" | "spring" | "summer1" | "summer2")[] = [
+  "fall",
+  "spring",
+  "summer1",
+  "summer2",
+];
+
+/**
+ * Gets all courses from the given plan. Courses taken multiple times are
+ * included in the result.
+ *
+ * @param   plan The plan to pull courses from.
+ * @returns      All courses in the plan.
+ */
+export const getAllCoursesFromPlan = (
+  plan: PlanModel<string>
+): ScheduleCourse2<unknown>[] => {
+  const courses: ScheduleCourse2<unknown>[] = [];
+  plan.schedule.years.forEach((year) => {
+    YearSeasons.forEach((season) => {
+      year[season].classes.forEach((course) => {
+        courses.push(course);
+      });
+    });
+  });
+  return courses;
+};

--- a/packages/frontend-v2/utils/plan/getSectionError.ts
+++ b/packages/frontend-v2/utils/plan/getSectionError.ts
@@ -1,0 +1,53 @@
+import {
+  MajorValidationError,
+  MajorValidationErrorType,
+  MajorValidationResult,
+  ResultType,
+} from "@graduate/common";
+
+/**
+ * Gets the error object for a given section if it exists from the
+ * MajorValidationResult object.
+ *
+ * @param   index            The index of the section
+ * @param   validationStatus The result of major validation
+ * @returns                  The error for that section or undefined.
+ */
+export const getSectionError = (
+  index: number,
+  validationStatus: MajorValidationResult | undefined
+): MajorValidationError | undefined => {
+  // Find the error for this sidebar component
+  if (validationStatus && validationStatus.type == ResultType.Err) {
+    // Both these cases should be unreachable, but help to narrow types
+    if (!validationStatus.err.majorRequirementsError)
+      throw new Error("Top level requirement should have an error.");
+    if (
+      validationStatus.err.majorRequirementsError.type !==
+      MajorValidationErrorType.And.Type
+    )
+      throw new Error("Top level requirement error should be AND.");
+
+    const andReq = validationStatus.err.majorRequirementsError?.error;
+    if (andReq.type == MajorValidationErrorType.And.UnsatChild) {
+      return andReq.childErrors.find((error) => {
+        return error.childIndex === index;
+      });
+    } else if (
+      andReq.type == MajorValidationErrorType.And.NoSolution &&
+      andReq.discoveredAtChild == index
+    ) {
+      // Create a section error so we don't display a check on the section that
+      // caused the "no solution" error.
+      return {
+        type: "SECTION",
+        sectionTitle: "No Solution Section",
+        childErrors: [],
+        minRequiredChildCount: 0,
+        maxPossibleChildCount: 0,
+      };
+    }
+
+    return undefined;
+  }
+};


### PR DESCRIPTION
# Description

https://user-images.githubusercontent.com/2746893/202877856-ecaacbcb-fe57-4f30-bd4c-9c08207afee5.mp4

This PR adds allows users to see major validation information in the sidebar. It also has small styling tweaks to the sidebar sections. 

There are still a few issues (validation algorithm bug and performance issues with near-full schedules) that should be resolved regarding major validation before alpha, but this PR will introduce the core functionality.

Closes #489 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually by trying various schedules in Firefox.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
