### PR TITLE
Fix Major Validation Double-Counting

### DIFF
--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -514,7 +514,6 @@ function validateAndRequirement(
   r: IAndCourse2,
   tracker: CourseValidationTracker
 ): Result<Array<Solution>, MajorValidationError> {
-  // const splitResults = validateAndSplit(r.courses, tracker);
   const results = validateRequirements(r.courses, tracker);
   const [allChildReqSolutions, childErrors] = splitChildResults(results);
 

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -101,11 +101,14 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
           const sectionValidationError: MajorValidationError | undefined =
             getSectionError(index, validationStatus);
 
+          const sectionIsValid =
+            selectedPlan !== undefined && sectionValidationError === undefined;
+
           return (
             <SidebarSection
               key={section.title}
               section={section}
-              validationStatus={sectionValidationError}
+              isValid={sectionIsValid}
               courseData={courseData}
               dndIdPrefix={"sidebar-" + index}
             />

--- a/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
+++ b/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
@@ -11,18 +11,17 @@ interface SidebarSectionProps {
   section: Section;
   courseData: { [id: string]: ScheduleCourse2<null> };
   dndIdPrefix: string;
-  validationStatus?: MajorValidationError;
+  isValid: boolean;
 }
 
 const SidebarSection: React.FC<SidebarSectionProps> = ({
   section,
   courseData,
   dndIdPrefix,
-  validationStatus,
+  isValid,
 }) => {
   const [opened, setOpened] = useState(false);
 
-  const isComplete = validationStatus == undefined;
   return (
     <Box borderTop="1px solid white" cursor="pointer" userSelect="none">
       <Text
@@ -42,7 +41,7 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
           backgroundColor: "neutral.200",
         }}
       >
-        {isComplete ? (
+        {isValid ? (
           <span
             style={{
               background: "green",

--- a/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
+++ b/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
@@ -1,9 +1,5 @@
 import { Box, Text } from "@chakra-ui/react";
-import {
-  MajorValidationError,
-  ScheduleCourse2,
-  Section,
-} from "@graduate/common";
+import { ScheduleCourse2, Section } from "@graduate/common";
 import { useState } from "react";
 import SectionRequirement from "./SectionRequirement";
 

--- a/packages/frontend-v2/utils/plan/getSectionError.ts
+++ b/packages/frontend-v2/utils/plan/getSectionError.ts
@@ -46,6 +46,20 @@ export const getSectionError = (
         minRequiredChildCount: 0,
         maxPossibleChildCount: 0,
       };
+    } else if (andReq.type == MajorValidationErrorType.And.UnsatChildAndNoSolution) {
+      if (andReq.noSolution.discoveredAtChild === index) {
+        return {
+          type: "SECTION",
+          sectionTitle: "No Solution Section",
+          childErrors: [],
+          minRequiredChildCount: 0,
+          maxPossibleChildCount: 0,
+        };
+      } else {
+        return andReq.unsatChildErrors.childErrors.find((error) => {
+          return error.childIndex === index;
+        });
+      }
     }
 
     return undefined;


### PR DESCRIPTION
# Description

https://user-images.githubusercontent.com/2746893/204439039-02577a94-3157-4445-acc9-061a3dfd3c01.mp4


Fixes an edge case where courses could be double counted because major validation could only return either an AndUnsatRequirements error or a AndNoSolution error but not both. As a result if there were any unsatisfied children in an And it would mask the NoSolution error, resulting in not enough errors being returned. This caused the UI to check off both sections despite such a solution being impossible.

Also makes some code clarity changes to how the section errors are propagated.

Closes #503 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been manually tested and some automated tests were added in `major2-validation.test.ts` that cover the case that this fixes.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
