### PR TITLE
Silence yarn install in Dockerfiles

### DIFF
--- a/infrastructure/prod/Dockerfile.app
+++ b/infrastructure/prod/Dockerfile.app
@@ -15,7 +15,7 @@ COPY packages/api-client/package.json packages/api-client/package.json
 COPY packages/common/package.json packages/common/package.json
 
 # Install at root level
-RUN yarn install
+RUN yarn install > /dev/null
 
 # Get src files
 COPY packages/frontend-v2 packages/frontend-v2

--- a/infrastructure/prod/Dockerfile.server
+++ b/infrastructure/prod/Dockerfile.server
@@ -10,7 +10,7 @@ COPY packages/common/package.json packages/common/package.json
 
 
 # Install at root level
-RUN yarn install
+RUN yarn install > /dev/null
 
 # Get src files
 COPY packages/api-v2 packages/api-v2


### PR DESCRIPTION
# Description

### ℹ️ This PR can wait until after Alpha, it's just a developer experience thing.

This PR silences the stdout logging of the yarn install in our two Dockerfiles. This it to make the output more readable so we can more easily see the reason a CI is error-ing. Right now, the yarn install logs ~5,000 lines (see below), which pushes the relevant error very far down into the logs.

<img width="1060" alt="Screen Shot 2022-12-02 at 5 00 58 PM" src="https://user-images.githubusercontent.com/2746893/205398236-34fc044a-802a-4b31-a0ca-dd66e9254c8f.png">

<img width="1061" alt="Screen Shot 2022-12-02 at 5 01 50 PM" src="https://user-images.githubusercontent.com/2746893/205398259-f0a1e489-0734-4554-9d5d-b936d9e17800.png">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I manually rebuilt the Dockerfiles and sanity checked that redirecting the output didn't break anything.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
