### PR TITLE
Add a loading indicator to Sidebar sections

### DIFF
--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -85,6 +85,10 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
         setLoading(false);
       }
     });
+    // We don't want to make another request when only courseData changes,
+    // we're just appending to it rather than replacing it, hence the
+    // technical dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [major.requirementSections]);
 
   return (

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -53,6 +53,7 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
   }, [selectedPlan, major]);
 
   const [courseData, setCourseData] = useState({});
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const requirements = major.requirementSections.reduce(
@@ -73,7 +74,7 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
     }
 
     SearchAPI.fetchCourses(coursesQueryData).then((courses) => {
-      const courseMap: { [id: string]: ScheduleCourse2<null> } = {};
+      const courseMap: { [id: string]: ScheduleCourse2<null> } = courseData;
       if (courses) {
         for (const course of courses) {
           if (course) {
@@ -81,6 +82,7 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
           }
         }
         setCourseData(courseMap);
+        setLoading(false);
       }
     });
   }, [major.requirementSections]);
@@ -111,6 +113,7 @@ const Sidebar: React.FC<SidebarProps> = memo(({ major, selectedPlan }) => {
               isValid={sectionIsValid}
               courseData={courseData}
               dndIdPrefix={"sidebar-" + index}
+              loading={loading}
             />
           );
         })}

--- a/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
+++ b/packages/frontend-v2/components/Sidebar/SidebarSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Flex, Spinner, Text } from "@chakra-ui/react";
 import { ScheduleCourse2, Section } from "@graduate/common";
 import { useState } from "react";
 import SectionRequirement from "./SectionRequirement";
@@ -8,6 +8,7 @@ interface SidebarSectionProps {
   courseData: { [id: string]: ScheduleCourse2<null> };
   dndIdPrefix: string;
   isValid: boolean;
+  loading?: boolean;
 }
 
 const SidebarSection: React.FC<SidebarSectionProps> = ({
@@ -15,6 +16,7 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
   courseData,
   dndIdPrefix,
   isValid,
+  loading,
 }) => {
   const [opened, setOpened] = useState(false);
 
@@ -61,7 +63,14 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
         padding="10px 20px 15px 10px"
         cursor="default"
       >
+        {loading && (
+          <Flex alignItems="center">
+            <Spinner size="sm"></Spinner>
+            <Text marginLeft="xs">Loading...</Text>
+          </Flex>
+        )}
         {opened &&
+          !loading &&
           section.requirements.map((requirement, index) => (
             <SectionRequirement
               requirement={requirement}


### PR DESCRIPTION
# Description

Adds a loading message to the sidebar sections while we wait for the Search API request to come back.

https://user-images.githubusercontent.com/2746893/205402507-ec7f3a3a-019f-406f-8434-5cc290da75f7.mp4

Closes #490 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual tests to check that this works as intended both when the API request succeeds and fails.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
