### PR TITLE
Small BSCS Major Fix

### DIFF
--- a/packages/api-v2/src/major/majors/2022/bscs.json
+++ b/packages/api-v2/src/major/majors/2022/bscs.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "SECTION",
-      "minRequirementCount": 4,
+      "minRequirementCount": 3,
       "requirements": [
         {
           "type": "AND",


### PR DESCRIPTION
# Description

This PR fixes a typo in the BSCS Major (4 required subsections in a section where there were only 3). This prevented the "Computer Science Fundamental Courses" section from being completed in the UI as it returned an error in major validation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested with the validation algorithm UI.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
