### PR TITLE
Fix build issues with class transformer and api

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,7 +15,10 @@ module.exports = function (api) {
           ],
           "@babel/preset-typescript",
         ],
-        plugins: [["@babel/plugin-proposal-decorators", { version: "legacy" }]],
+        plugins: [
+          ["@babel/plugin-proposal-decorators", { version: "legacy" }],
+          "@babel/plugin-proposal-class-properties",
+        ],
         babelrcRoots: [".", "packages/*"],
       },
       browser: {
@@ -47,7 +50,10 @@ module.exports = function (api) {
           ],
           "@babel/preset-typescript",
         ],
-        plugins: [["@babel/plugin-proposal-decorators", { version: "legacy" }]],
+        plugins: [
+          ["@babel/plugin-proposal-decorators", { version: "legacy" }],
+          "@babel/plugin-proposal-class-properties",
+        ],
         babelrcRoots: [".", "packages/*"],
       },
     },

--- a/packages/api-v2/nest-cli.json
+++ b/packages/api-v2/nest-cli.json
@@ -1,4 +1,3 @@
 {
-  "collection": "@nestjs/schematics",
-  "sourceRoot": "api-v2/src"
+  "collection": "@nestjs/schematics"
 }

--- a/packages/api-v2/package.json
+++ b/packages/api-v2/package.json
@@ -13,7 +13,7 @@
     "dev": "NODE_ENV=development nest start --watch",
     "prod": "yarn build && yarn start:prod",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "NODE_ENV=production node dist/api-v2/src/main",
+    "start:prod": "NODE_ENV=production node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/api-v2/src/auth/auth.controller.ts
+++ b/packages/api-v2/src/auth/auth.controller.ts
@@ -13,7 +13,7 @@ import {
   GetStudentResponse,
   LoginStudentDto,
   SignUpStudentDto,
-} from "../../../common";
+} from "@graduate/common";
 import { Response } from "express";
 
 @Controller("auth")

--- a/packages/api-v2/src/auth/auth.service.ts
+++ b/packages/api-v2/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
 import { Student } from "../../src/student/entities/student.entity";
 import { StudentService } from "../../src/student/student.service";
-import { LoginStudentDto, SignUpStudentDto } from "../../../common";
+import { LoginStudentDto, SignUpStudentDto } from "@graduate/common";
 import { JwtPayload } from "./interfaces/jwt-payload";
 import * as bcrypt from "bcrypt";
 import { formatServiceCtx } from "../../src/utils";

--- a/packages/api-v2/src/main.ts
+++ b/packages/api-v2/src/main.ts
@@ -26,6 +26,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true, // strips properties from incoming objects that aren't decorated with class-validator
+      transformOptions: { exposeUnsetFields: false },
       transform: true, // transforms properties from incoming objects to the type they are decorated with by class-validator
     })
   );

--- a/packages/api-v2/src/major/major.controller.ts
+++ b/packages/api-v2/src/major/major.controller.ts
@@ -1,4 +1,4 @@
-import { GetSupportedMajorsResponse, Major2 } from "../../../common";
+import { GetSupportedMajorsResponse, Major2 } from "@graduate/common";
 import {
   Controller,
   Get,

--- a/packages/api-v2/src/plan/plan.controller.ts
+++ b/packages/api-v2/src/plan/plan.controller.ts
@@ -20,7 +20,7 @@ import {
   UpdatePlanDto,
   GetPlanResponse,
   UpdatePlanResponse,
-} from "../../../common";
+} from "@graduate/common";
 
 @Controller("plans")
 export class PlanController {

--- a/packages/api-v2/src/plan/plan.service.ts
+++ b/packages/api-v2/src/plan/plan.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Student } from "../student/entities/student.entity";
 import { StudentService } from "../student/student.service";
 import { DeleteResult, Repository, UpdateResult } from "typeorm";
-import { CreatePlanDto, UpdatePlanDto } from "../../../common";
+import { CreatePlanDto, UpdatePlanDto } from "@graduate/common";
 import { Plan } from "./entities/plan.entity";
 import { formatServiceCtx } from "../../src/utils";
 import { MajorService } from "../major/major.service";

--- a/packages/api-v2/src/plan/plan.service.ts
+++ b/packages/api-v2/src/plan/plan.service.ts
@@ -109,7 +109,6 @@ export class PlanService {
     id: number,
     updatePlanDto: UpdatePlanDto
   ): Promise<UpdateResult> {
-    console.log("HAI");
     const {
       major: newMajorName,
       catalogYear: newCatalogYear,
@@ -139,7 +138,6 @@ export class PlanService {
     const isScheduleUpdate = newSchedule && !isMajorInfoUpdate;
 
     if (!(isMajorInfoUpdate || isScheduleUpdate)) {
-      console.log("YO");
       this.logger.debug(
         { message: "Either update all major fields or only the schedule", id },
         this.formatPlanServiceCtx("update")

--- a/packages/api-v2/src/plan/plan.service.ts
+++ b/packages/api-v2/src/plan/plan.service.ts
@@ -201,6 +201,8 @@ export class PlanService {
       }
     }
 
+    console.log("UPDATE DTO: ", updatePlanDto);
+
     const updateResult = await this.planRepository.update(id, updatePlanDto);
 
     if (updateResult.affected === 0) {

--- a/packages/api-v2/src/student/student.controller.ts
+++ b/packages/api-v2/src/student/student.controller.ts
@@ -25,7 +25,7 @@ import {
   OnboardStudentDto,
   UpdateStudentDto,
   UpdateStudentResponse,
-} from "../../../common";
+} from "@graduate/common";
 
 @Controller("students")
 export class StudentController {

--- a/packages/api-v2/src/student/student.service.ts
+++ b/packages/api-v2/src/student/student.service.ts
@@ -7,7 +7,7 @@ import {
   Repository,
   UpdateResult,
 } from "typeorm";
-import { SignUpStudentDto, UpdateStudentDto } from "../../../common";
+import { SignUpStudentDto, UpdateStudentDto } from "@graduate/common";
 import { Student } from "./entities/student.entity";
 
 @Injectable()


### PR DESCRIPTION
# Description

## Context
- We have a common package with API response types
- We use babel to build the common package
- We fail to build these types in a way that is compatible with class transformer library used in the API
- Hence, instead of using the build we simply import the types directly from the file using the path which isn't the pattern used in the codebase

## Fix
- After some stackoverflowing, I realized that we need the @babel/plugin-proposal-class-properties plugin after the @babel/plugin-proposal-decorators plugin in our babel config to build properly.

Closes #517 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- yarn dev:v2 works
- yarn prod:v2 works: this uses production build for common

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
