### PR TITLE
Dylan rework blank screen

### DIFF
--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -87,6 +87,7 @@ const HomePage: NextPage = () => {
   useEffect(() => {
     // once the student is fetched, set the selected plan id to the primary plan id
     if (student && selectedPlanId === undefined) {
+      console.log("Student Plan ID: " + student.primaryPlanId);
       setSelectedPlanId(student.primaryPlanId);
     }
     if (student) {

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -87,8 +87,13 @@ const HomePage: NextPage = () => {
   useEffect(() => {
     // once the student is fetched, set the selected plan id to the primary plan id
     if (student && selectedPlanId === undefined) {
-      console.log("Student Plan ID: " + student.primaryPlanId);
-      setSelectedPlanId(student.primaryPlanId);
+      if(student.primaryPlanId == null){
+        if(student.plans){
+          setSelectedPlanId(student.plans[0].id);
+        }
+      } else {
+        setSelectedPlanId(student.primaryPlanId);
+      }
     }
     if (student) {
       const plan = student.plans.find((plan) => plan.id === selectedPlanId);

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -87,13 +87,9 @@ const HomePage: NextPage = () => {
   useEffect(() => {
     // once the student is fetched, set the selected plan id to the primary plan id
     if (student && selectedPlanId === undefined) {
-      if(student.primaryPlanId == null){
-        if(student.plans.length > 0){
-          const sortedPlans = student.plans.sort((p1, p2) => p1.createdAt.getTime() - p2.createdAt.getTime())
-          setSelectedPlanId(sortedPlans[0].id);
-        }
-      } else {
-        setSelectedPlanId(student.primaryPlanId);
+      if(student.plans.length > 0){
+        const sortedPlans = student.plans.sort((p1, p2) => p1.updatedAt.getTime() - p2.updatedAt.getTime())
+        setSelectedPlanId(sortedPlans[0].id);
       }
     }
     if (student) {

--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -88,8 +88,9 @@ const HomePage: NextPage = () => {
     // once the student is fetched, set the selected plan id to the primary plan id
     if (student && selectedPlanId === undefined) {
       if(student.primaryPlanId == null){
-        if(student.plans){
-          setSelectedPlanId(student.plans[0].id);
+        if(student.plans.length > 0){
+          const sortedPlans = student.plans.sort((p1, p2) => p1.createdAt.getTime() - p2.createdAt.getTime())
+          setSelectedPlanId(sortedPlans[0].id);
         }
       } else {
         setSelectedPlanId(student.primaryPlanId);


### PR DESCRIPTION
# Description

Adjusted the useEffect in home.tsx so that upon loading the page we find the latest plan created by the user 
and displays it instead of simply displaying a blank screen and waiting for the user to choose a plan. 


Closes # 551

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a new user with no plans and made sure the same behavior as before is performed. Created a student 
with one plan to test if it worked with a list of one. Made a student with multiple plans and see if it displays the 
correct plan.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed 
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
