### PR TITLE
Implement courses by catalog year

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -104,7 +104,7 @@ function occurrencesToCourseByCatalogYear(
   for (const occurrence of occurrences) {
     const year = occurrence.termId.slice(0, 4);
 
-    if (year === catalogYear.toString()) {
+    if (year + 1 === catalogYear.toString()) {
       return occurrenceToCourse(occurrence);
     }
   }

--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -101,6 +101,10 @@ function occurrencesToCourseByCatalogYear(
   occurrences: SearchClass[],
   catalogYear: number
 ): ScheduleCourse2<null> {
+  if (!occurrences || occurrences.length === 0) {
+    throw Error("Course not found");
+  }
+
   for (const occurrence of occurrences) {
     const year = occurrence.termId.slice(0, 4);
 

--- a/packages/frontend-v2/components/AddCourseModal/AddCourseModal.tsx
+++ b/packages/frontend-v2/components/AddCourseModal/AddCourseModal.tsx
@@ -27,6 +27,7 @@ import { SelectedCourse } from "./SelectedCourse";
 
 interface AddCourseModalProps {
   isOpen: boolean;
+  catalogYear: number;
   /** Function to close the modal UX, returned from the useDisclosure chakra hook */
   closeModalDisplay: () => void;
 
@@ -39,6 +40,7 @@ interface AddCourseModalProps {
 
 export const AddCourseModal: React.FC<AddCourseModalProps> = ({
   isOpen,
+  catalogYear,
   closeModalDisplay,
   isCourseInCurrTerm,
   addClassesToCurrTerm,
@@ -63,13 +65,15 @@ export const AddCourseModal: React.FC<AddCourseModalProps> = ({
     const updatedSelectedCourses = [...selectedCourses];
 
     // grab any coreqs of the course that haven't already been selected/added to the term
-    const coreqs = (await getRequiredCourseCoreqs(course)).filter((coreq) => {
-      const isAlreadySelected = selectedCourses.find((selectedCourse) =>
-        isEqualCourses(selectedCourse, coreq)
-      );
-      const isAlreadyAdded = isCourseInCurrTerm(coreq);
-      return !(isAlreadyAdded || isAlreadySelected);
-    });
+    const coreqs = (await getRequiredCourseCoreqs(course, catalogYear)).filter(
+      (coreq) => {
+        const isAlreadySelected = selectedCourses.find((selectedCourse) =>
+          isEqualCourses(selectedCourse, coreq)
+        );
+        const isAlreadyAdded = isCourseInCurrTerm(coreq);
+        return !(isAlreadyAdded || isAlreadySelected);
+      }
+    );
 
     updatedSelectedCourses.push(course, ...coreqs);
 

--- a/packages/frontend-v2/components/AddCourseModal/AddCourseModal.tsx
+++ b/packages/frontend-v2/components/AddCourseModal/AddCourseModal.tsx
@@ -155,20 +155,22 @@ export const AddCourseModal: React.FC<AddCourseModalProps> = ({
           </VStack>
         </ModalBody>
         <ModalFooter>
-          <Button
-            variant="solid"
-            fontWeight="bold"
-            color="primary.blue.light.main"
-            colorScheme="neutral"
-            backgroundColor="neutral.main"
-            border="none"
-            mr={3}
-            onClick={addClassesOnClick}
-            textTransform="uppercase"
-            isLoading={isCoursesLoading}
-          >
-            Add
-          </Button>
+          <Tooltip label="Note that search results will reflect the most recent version of the course you're looking for!">
+            <Button
+              variant="solid"
+              fontWeight="bold"
+              color="primary.blue.light.main"
+              colorScheme="neutral"
+              backgroundColor="neutral.main"
+              border="none"
+              mr={3}
+              onClick={addClassesOnClick}
+              textTransform="uppercase"
+              isLoading={isCoursesLoading}
+            >
+              Add
+            </Button>
+          </Tooltip>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/packages/frontend-v2/components/Plan/Plan.tsx
+++ b/packages/frontend-v2/components/Plan/Plan.tsx
@@ -17,7 +17,7 @@ interface PlanProps {
   plan: PlanModel<string>;
   preReqErr?: PreReqWarnings;
   coReqErr?: CoReqWarnings;
-  setIsRemove?: (val: boolean) => void
+  setIsRemove?: (val: boolean) => void;
 
   /**
    * Function to POST the plan and update the SWR cache for "student with plans"
@@ -31,7 +31,7 @@ export const Plan: React.FC<PlanProps> = ({
   mutateStudentWithUpdatedPlan,
   preReqErr = undefined,
   coReqErr = undefined,
-  setIsRemove
+  setIsRemove,
 }) => {
   const [expandedYears, setExpandedYears] = useState<Set<number>>(new Set());
 
@@ -43,7 +43,7 @@ export const Plan: React.FC<PlanProps> = ({
     }
   };
 
-  const { setNodeRef } = useDroppable({ id: 'plan' });
+  const { setNodeRef } = useDroppable({ id: "plan" });
 
   const removeFromExpandedYears = (year: ScheduleYear2<unknown>) => {
     const updatedSet = new Set(expandedYears);
@@ -119,6 +119,7 @@ export const Plan: React.FC<PlanProps> = ({
             flexDirection="column"
           >
             <ScheduleYear
+              catalogYear={plan.catalogYear}
               yearCoReqError={coReqErr?.years.find(
                 (year) => year.year == scheduleYear.year
               )}

--- a/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleTerm.tsx
@@ -15,6 +15,7 @@ import { BlueButton } from "../Button";
 
 interface ScheduleTermProps {
   scheduleTerm: ScheduleTerm2<string>;
+  catalogYear: number;
   yearNum: number;
   termCoReqErr?: TermError;
   termPreReqErr?: TermError;
@@ -34,11 +35,12 @@ interface ScheduleTermProps {
   ) => void;
 
   isLastColumn?: boolean;
-  setIsRemove?: (val: boolean) => void
+  setIsRemove?: (val: boolean) => void;
 }
 
 export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
   scheduleTerm,
+  catalogYear,
   addClassesToTermInCurrPlan,
   yearNum,
   removeCourseFromTermInCurrPlan,
@@ -84,6 +86,7 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
       <AddCourseButton onOpen={onOpen} />
       <AddCourseModal
         isOpen={isOpen}
+        catalogYear={catalogYear}
         closeModalDisplay={onClose}
         isCourseInCurrTerm={isCourseInCurrTerm}
         addClassesToCurrTerm={(courses: ScheduleCourse2<null>[]) =>

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -16,6 +16,7 @@ interface ToggleYearProps {
 
 interface ScheduleYearProps extends ToggleYearProps {
   scheduleYear: ScheduleYear2<string>;
+  catalogYear: number;
   yearCoReqError?: YearError;
   yearPreReqError?: YearError;
 
@@ -35,11 +36,12 @@ interface ScheduleYearProps extends ToggleYearProps {
 
   /** Function to remove the curr year from the plan */
   removeYearFromCurrPlan: () => void;
-  setIsRemove?: (val: boolean) => void
+  setIsRemove?: (val: boolean) => void;
 }
 
 export const ScheduleYear: React.FC<ScheduleYearProps> = ({
   scheduleYear,
+  catalogYear,
   addClassesToTermInCurrPlan,
   removeCourseFromTermInCurrPlan,
   isExpanded,
@@ -96,6 +98,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
         <Grid templateColumns="repeat(4, 1fr)" minHeight="220px">
           <ScheduleTerm
             yearNum={scheduleYear.year}
+            catalogYear={catalogYear}
             termCoReqErr={yearCoReqError?.fall}
             termPreReqErr={yearPreReqError?.fall}
             scheduleTerm={scheduleYear.fall}
@@ -105,6 +108,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
           />
           <ScheduleTerm
             yearNum={scheduleYear.year}
+            catalogYear={catalogYear}
             termCoReqErr={yearCoReqError?.spring}
             termPreReqErr={yearPreReqError?.spring}
             scheduleTerm={scheduleYear.spring}
@@ -114,6 +118,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
           />
           {/* TODO: support summer full term */}
           <ScheduleTerm
+            catalogYear={catalogYear}
             yearNum={scheduleYear.year}
             termCoReqErr={yearCoReqError?.summer1}
             termPreReqErr={yearPreReqError?.summer1}
@@ -123,6 +128,7 @@ export const ScheduleYear: React.FC<ScheduleYearProps> = ({
             setIsRemove={setIsRemove}
           />
           <ScheduleTerm
+            catalogYear={catalogYear}
             yearNum={scheduleYear.year}
             termCoReqErr={yearCoReqError?.summer2}
             termPreReqErr={yearPreReqError?.summer2}

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -142,7 +142,7 @@ const Sidebar: React.FC<SidebarProps> = memo(({ selectedPlan }) => {
     courses,
     isLoading: isCoursesLoading,
     error: courseErrors,
-  } = useFetchCourses(majorCourses);
+  } = useFetchCourses(majorCourses, selectedPlan.catalogYear);
 
   const courseData = createCourseMap(courses, courseErrors);
 

--- a/packages/frontend-v2/hooks/useFetchCourses.ts
+++ b/packages/frontend-v2/hooks/useFetchCourses.ts
@@ -19,10 +19,13 @@ type courses = { subject: string; classId: string }[];
  * @param subject - The type of class that we are fetching from SearchNEU
  * @param classId - The identification number of the class as a string
  */
-export function useFetchCourses(courses: courses): FetchCoursesReturn {
+export function useFetchCourses(
+  courses: courses,
+  catalogYear: number
+): FetchCoursesReturn {
   const { data, ...rest } = useSWR(
     `/fetchCourses/${courses}`,
-    async () => await SearchAPI.fetchCourses(courses)
+    async () => await SearchAPI.fetchCourses(courses, catalogYear)
   );
 
   return {

--- a/packages/frontend-v2/utils/course/getCourseCoreqs.ts
+++ b/packages/frontend-v2/utils/course/getCourseCoreqs.ts
@@ -3,7 +3,8 @@ import { ScheduleCourse2, INEUReq, INEUReqCourse } from "@graduate/common";
 
 /** Get all the required(ANDs only) coreqs for a given course. */
 export async function getRequiredCourseCoreqs(
-  course: ScheduleCourse2<unknown>
+  course: ScheduleCourse2<unknown>,
+  catalogYear: number
 ): Promise<ScheduleCourse2<null>[]> {
   const coursesCoreqs: ScheduleCourse2<null>[] = [];
 
@@ -17,7 +18,8 @@ export async function getRequiredCourseCoreqs(
         if (isINEUPrereqCourse(coreqCourse)) {
           const course = await SearchAPI.fetchCourse(
             coreqCourse.subject,
-            coreqCourse.classId
+            coreqCourse.classId,
+            catalogYear
           );
 
           if (course != null) {


### PR DESCRIPTION
# Description

Update course fetching to be by catalog year (getting all occurrences of a course and filtering by catalog year), fallback to latest occurrence of the course 

Closes # (519)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [X] honestly just console logging the catalog year and parsed term id (to get catalog year from search response) and making sure they match up lmao

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
