### PR TITLE
Hotfix for multiple plans

### DIFF
--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -88,7 +88,7 @@ const HomePage: NextPage = () => {
     if (student && selectedPlanId === undefined) {
       if (student.plans.length > 0) {
         const sortedPlans = student.plans.sort(
-          (p1, p2) => p1.updatedAt.getTime() - p2.updatedAt.getTime()
+          (p1, p2) => new Date(p1.updatedAt).getTime() - new Date(p2.updatedAt).getTime()
         );
         setSelectedPlanId(sortedPlans[0].id);
       }


### PR DESCRIPTION
# Description

Somehow the updatedAt property is being sent as a string somewhere along the process so when `getTime` is called, it crashes the app. To prevent this, I'm just converting the dates explicitly. This has no effect on existing dates (so it's safe to include even if the issue isn't consistent), but converts strings to the correct date, allowing the `getTime` method to be run.

Something is wrong somewhere else in the app that's causing this, but this mitigates the symptoms in the short term.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested to check that this fixes the problem.

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
