### PR TITLE
UX-Fixes

### DIFF
--- a/packages/frontend-v2/components/Authentication/ResendEmailVerificationLink.tsx
+++ b/packages/frontend-v2/components/Authentication/ResendEmailVerificationLink.tsx
@@ -3,7 +3,8 @@ import { handleApiClientError, toast } from "../../utils";
 import { useRouter } from "next/router";
 import axios from "axios";
 import { emailAlreadyConfirmed, unableToSendEmail } from "@graduate/common";
-import { Link } from "@chakra-ui/react";
+import { Button } from "@chakra-ui/react";
+import { useState } from "react";
 
 interface ResendEmailVerificationLinkProps {
   label: string;
@@ -12,7 +13,9 @@ interface ResendEmailVerificationLinkProps {
 export const ResendEmailVerificationLink: React.FC<
   ResendEmailVerificationLinkProps
 > = ({ label }) => {
+  const [isDisabled, setIsDisabled] = useState(false);
   const router = useRouter();
+
   const handleResendConfirmationEmail = async () => {
     try {
       await API.email.resendConfirmationLink();
@@ -22,7 +25,7 @@ export const ResendEmailVerificationLink: React.FC<
         const errorMessage = err.response?.data?.message;
         if (errorMessage === emailAlreadyConfirmed) {
           router.push("home");
-          toast.info("Your email has already been verfied!");
+          toast.info("Your email has already been verified!");
           return;
         }
 
@@ -38,13 +41,19 @@ export const ResendEmailVerificationLink: React.FC<
   };
 
   return (
-    <Link
-      onClick={handleResendConfirmationEmail}
+    <Button
+      isDisabled={isDisabled}
+      onClick={async () => {
+        setIsDisabled(true);
+        await handleResendConfirmationEmail();
+        setIsDisabled(false);
+      }}
+      variant="link"
       color="primary.blue.light.main"
       fontWeight="bold"
       fontSize="sm"
     >
       {label}
-    </Link>
+    </Button>
   );
 };

--- a/packages/frontend-v2/components/Header/AccountOverview.tsx
+++ b/packages/frontend-v2/components/Header/AccountOverview.tsx
@@ -49,7 +49,7 @@ export const AccountOverview: React.FC<AccountOverviewProps> = ({
     trigger,
     reset,
   } = useForm<UpdateName>({
-    mode: "onTouched",
+    mode: "onChange",
     shouldFocusError: true,
   });
 
@@ -152,7 +152,7 @@ export const AccountOverview: React.FC<AccountOverviewProps> = ({
                   >
                     <WarningTwoIcon color="states.warning.main" />
                   </GraduateToolTip>
-                  <ResendEmailVerificationLink label="Send Verfication Email" />
+                  <ResendEmailVerificationLink label="Send Verification Email" />
                 </Flex>
               </FormControl>
             </Flex>

--- a/packages/frontend-v2/components/Header/ChangePassword.tsx
+++ b/packages/frontend-v2/components/Header/ChangePassword.tsx
@@ -27,7 +27,7 @@ import {
 import { useForm } from "react-hook-form";
 import { GraduateInput } from "../Form";
 import { useRouter } from "next/router";
-import { handlWeakPasswordError } from "../../utils/error";
+import { handleWeakPasswordError } from "../../utils/error";
 
 export const ChangePassword: React.FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -40,7 +40,7 @@ export const ChangePassword: React.FC = () => {
     watch,
     trigger,
   } = useForm<ChangePasswordDto>({
-    mode: "onTouched",
+    mode: "onChange",
     shouldFocusError: true,
   });
 
@@ -64,7 +64,7 @@ export const ChangePassword: React.FC = () => {
           return;
         }
 
-        if (handlWeakPasswordError(errorMessage)) {
+        if (handleWeakPasswordError(errorMessage)) {
           return;
         }
       }

--- a/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
+++ b/packages/frontend-v2/components/Plan/ReqErrorModal.tsx
@@ -24,8 +24,10 @@ import {
 } from "../../utils";
 import { useFetchCourse } from "../../hooks";
 import { GraduateToolTip } from "../GraduateTooltip";
+import { SetStateAction } from "react";
 
 interface ReqErrorModalProps {
+  setHovered: (isHovered: SetStateAction<boolean>) => void;
   course: ScheduleCourse2<unknown>;
   preReqErr?: INEUReqError;
   coReqErr?: INEUReqError;
@@ -33,6 +35,7 @@ interface ReqErrorModalProps {
 
 export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
   course,
+  setHovered,
   coReqErr = undefined,
   preReqErr = undefined,
 }) => {
@@ -49,6 +52,7 @@ export const ReqErrorModal: React.FC<ReqErrorModalProps> = ({
       }}
       _active={{ background: "primary.red.900" }}
       onClick={() => {
+        setHovered(false)
         onOpen();
       }}
     >

--- a/packages/frontend-v2/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend-v2/components/Plan/ScheduleYear.tsx
@@ -180,8 +180,8 @@ const YearHeader: React.FC<YearHeaderProps> = ({
               variant="ghost"
               color="primary.red.main"
               icon={<WarningIcon />}
-              _hover={{ bg: `white` }}
-              _active={{}}
+              _hover={{ bg: 'none', cursor: 'auto' }}
+              _active={{ bg: `${backgroundColor}.900` }}
               onClick={(e) => {
                 if (isExpanded) {
                   e.stopPropagation();

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -241,6 +241,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
         <Flex>
           {isCourseError && (
             <ReqErrorModal
+              setHovered={setHovered}
               course={scheduleCourse}
               coReqErr={coReqErr}
               preReqErr={preReqErr}

--- a/packages/frontend-v2/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend-v2/components/Sidebar/Sidebar.tsx
@@ -206,12 +206,12 @@ const Sidebar: React.FC<SidebarProps> = memo(
           Presently, we try to to satisfy as many requirements as possible with
           your plan. Hence, while you are filling your plan in, some of your
           courses may temporarily satisfy a different requirement than intended.
-          We apologise for any confusion and are actively working on improving
+          We apologize for any confusion and are actively working on improving
           this.
         </Text>
         <Text>
           Finally, if you notice something incorrect in your requirements,
-          please let us know through the bug report button uptop!
+          please let us know through the bug report button up top!
         </Text>
       </Stack>
     );

--- a/packages/frontend-v2/pages/resetPassword.tsx
+++ b/packages/frontend-v2/pages/resetPassword.tsx
@@ -23,7 +23,7 @@ import {
   toast,
   WEAK_PASSWORD_MSG,
 } from "../utils";
-import { handlWeakPasswordError } from "../utils/error";
+import { handleWeakPasswordError } from "../utils/error";
 
 const ResetPassword: NextPage = () => {
   return (
@@ -70,7 +70,7 @@ const ResetPasswordContent: React.FC = () => {
           return;
         }
 
-        if (handlWeakPasswordError(errorMessage)) {
+        if (handleWeakPasswordError(errorMessage)) {
           return;
         }
       }

--- a/packages/frontend-v2/pages/signup.tsx
+++ b/packages/frontend-v2/pages/signup.tsx
@@ -22,7 +22,7 @@ import {
   toast,
   WEAK_PASSWORD_MSG,
 } from "../utils";
-import { handlWeakPasswordError } from "../utils/error";
+import { handleWeakPasswordError } from "../utils/error";
 
 const Signup: NextPage = () => {
   return <AuthenticationPageLayout form={<SignUpForm />} />;
@@ -38,7 +38,7 @@ const SignUpForm: React.FC = () => {
     watch,
     trigger,
   } = useForm<SignUpStudentDto>({
-    mode: "onTouched",
+    mode: "onChange",
     shouldFocusError: true,
   });
 
@@ -60,7 +60,7 @@ const SignUpForm: React.FC = () => {
           return;
         }
 
-        if (handlWeakPasswordError(errorMessage)) {
+        if (handleWeakPasswordError(errorMessage)) {
           return;
         }
       }

--- a/packages/frontend-v2/utils/error/handleWeakPasswordError.ts
+++ b/packages/frontend-v2/utils/error/handleWeakPasswordError.ts
@@ -6,7 +6,7 @@ import { WEAK_PASSWORD_MSG } from "../constants";
  * Handle the weak password error message if thrown by our API, and return
  * whether it was handled.
  */
-export const handlWeakPasswordError = (errorMessage: string): boolean => {
+export const handleWeakPasswordError = (errorMessage: string): boolean => {
   if (errorMessage === weakPasswordError) {
     toast.error(`Password too weak. ${WEAK_PASSWORD_MSG}`);
     return true;


### PR DESCRIPTION
# Description

Super quick UX fixes that I noticed while bug bashing. Most files are just typo errors (everyone please install a spell checker in your IDE).

Previously, when clicking the prereq/coreq error button, the selected schedule course will stay hovering. This just updates the state when the coreq/prereq modal opens 

https://user-images.githubusercontent.com/20124104/231635161-17194b26-266b-4ba2-a5c2-dce4766e329f.mov

Removes hover styling on schedule year error as it confuses users that there may be something to click on, when clicking on it just hides the tooltip

https://user-images.githubusercontent.com/20124104/231635268-02b859a8-349a-4688-980e-8beea6c68031.mov

Disable 'send verification button' as we are sending the email so users don't spam

https://user-images.githubusercontent.com/20124104/231635345-c019f7f3-642d-46af-af8d-f6a613c48633.mov

## Type of change

Please delete options that are not relevant.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
