### PR TITLE
Conditional rendering for 'email not verified' in account overview

### DIFF
--- a/packages/frontend-v2/components/Header/AccountOverview.tsx
+++ b/packages/frontend-v2/components/Header/AccountOverview.tsx
@@ -143,17 +143,19 @@ export const AccountOverview: React.FC<AccountOverviewProps> = ({
                   borderWidth="2px"
                   borderRadius="md"
                 />
-                <Flex alignItems="center" mt="xs" columnGap="xs">
-                  <GraduateToolTip
-                    placement="top"
-                    label="Your email is not verified yet. If you do not verify your
+                {!student.isEmailConfirmed && (
+                  <Flex alignItems="center" mt="xs" columnGap="xs">
+                    <GraduateToolTip
+                      placement="top"
+                      label="Your email is not verified yet. If you do not verify your
               email, you cannot recover your account if you forget your
               password."
-                  >
-                    <WarningTwoIcon color="states.warning.main" />
-                  </GraduateToolTip>
-                  <ResendEmailVerificationLink label="Send Verification Email" />
-                </Flex>
+                    >
+                      <WarningTwoIcon color="states.warning.main" />
+                    </GraduateToolTip>
+                    <ResendEmailVerificationLink label="Send Verification Email" />
+                  </Flex>
+                )}
               </FormControl>
             </Flex>
           </ModalBody>


### PR DESCRIPTION
# Description

Added conditional rendering for the send email verification link in the account overview

Closes #622

## Type of changes
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Shows tool tip when email has not been verified
- [x] Doesn't show tool tip when email is verified
# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
