### PR TITLE
Add "passwordConfirm" to Logging Denylist

### DIFF
--- a/packages/api-v2/src/graduate-logger.ts
+++ b/packages/api-v2/src/graduate-logger.ts
@@ -1,7 +1,7 @@
 import { ConsoleLogger, LogLevel } from "@nestjs/common";
 import { deepFilter } from "src/utils";
 
-const DENYLIST = ["password"];
+const DENYLIST = ["password", "passwordConfirm"];
 
 export class GraduateLogger extends ConsoleLogger {
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {


### PR DESCRIPTION
# Description
We are currently logging the passwordConfirm field production which is bad security practice. This PR removes the field by adding it to the denylist.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally.
