### PR TITLE
feat: allow temp vercel URL as origin (CORS)

### DIFF
--- a/packages/api-v2/src/main.ts
+++ b/packages/api-v2/src/main.ts
@@ -19,6 +19,10 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule, {
     logger: graduateLogger,
+    cors: {
+      origin:
+        "https://graduatenu-frontend-v2-git-christina-move-fro-b625a5-sandboxneu.vercel.app",
+    },
   });
 
   /**


### PR DESCRIPTION
# Description

Add a temporary Vercel URL to the allowlist for the backend, so that we can test the new setup (Vercel frontend) in staging.