### PR TITLE
Remove transfer course cursor styling

### DIFF
--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -114,6 +114,7 @@ export const NonDraggableScheduleCourse: React.FC<
       isDisabled={false}
       isEditable={true}
       removeCourse={removeCourse}
+      isDraggable={false}
     />
   );
 };
@@ -187,6 +188,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
       isRemove,
       isFromSidebar,
       isDraggable,
+      isDisabled,
     },
     ref
   ) => {
@@ -218,7 +220,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
           flex: scheduleCourse.classId === COOP_BLOCK.classId ? 1 : 0,
           marginBottom: "6px",
           transition: "transform 0.15s ease, opacity 0.25s ease",
-          transform: hovered ? "scale(1.04)" : "scale(1)",
+          transform: hovered && isDraggable ? "scale(1.04)" : "scale(1)",
           opacity: isValidRemove ? 0.5 : 1,
           justifyContent: "space-between",
           width: "100%",
@@ -321,7 +323,7 @@ const ScheduleCourseDraggedContents: React.FC<
     <div
       style={{
         padding: isDraggable ? "8px 8px" : "8px 12px",
-        cursor: isOverlay ? "grabbing" : "grab",
+        cursor: isOverlay ? "grabbing" : isDraggable ? "grab" : "default",
         flexGrow: "1",
       }}
       {...listeners}

--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -188,7 +188,6 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
       isRemove,
       isFromSidebar,
       isDraggable,
-      isDisabled,
     },
     ref
   ) => {


### PR DESCRIPTION
# Description

Previously, hovering over a transfer course changed cursor to a grab, and made it look like you could drag the course when you can't. This PR just fixes that by removing the hover animations .
Closes #654

## Type of change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# Checklist:

- [x] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
