### PR TITLE
Support for checkmarked courses in sidebar

### DIFF
--- a/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend-v2/components/ScheduleCourse/ScheduleCourse.tsx
@@ -1,5 +1,5 @@
-import { DeleteIcon } from "@chakra-ui/icons";
-import { Flex } from "@chakra-ui/react";
+import { DeleteIcon, CheckIcon } from "@chakra-ui/icons";
+import { Box, Flex } from "@chakra-ui/react";
 import { useDraggable } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import {
@@ -24,6 +24,8 @@ interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
   coReqErr?: INEUReqError;
   preReqErr?: INEUReqError;
+  isInSidebar?: boolean;
+  isChecked?: boolean;
   /** Function to remove the course from whatever the schedule it is part of. */
   removeCourse?: (course: ScheduleCourse2<unknown>) => void;
   isEditable?: boolean;
@@ -40,6 +42,8 @@ export const DraggableScheduleCourse: React.FC<
   removeCourse,
   preReqErr = undefined,
   coReqErr = undefined,
+  isInSidebar = false,
+  isChecked = false,
   isEditable = false,
   isDisabled = false,
   setIsRemove,
@@ -64,6 +68,8 @@ export const DraggableScheduleCourse: React.FC<
       ref={setNodeRef}
       scheduleCourse={scheduleCourse}
       removeCourse={removeCourse}
+      isInSidebar={isInSidebar}
+      isChecked={isChecked}
       isEditable={isEditable}
       isDragging={isDragging}
       listeners={listeners}
@@ -179,6 +185,8 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
       preReqErr = undefined,
       scheduleCourse,
       removeCourse,
+      isInSidebar = false,
+      isChecked = false,
       isEditable = false,
       isDragging = false,
       listeners,
@@ -238,7 +246,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
           isOverlay={isOverlay}
           isDraggable={isDraggable}
         />
-        <Flex>
+        <Flex alignItems={"center"}>
           {isCourseError && (
             <ReqErrorModal
               setHovered={setHovered}
@@ -254,6 +262,27 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
               }
             />
           )}
+          {isInSidebar && isChecked && (
+            <Box
+              bg={"states.success.main"}
+              borderColor={"states.success.main"}
+              color={"white"}
+              borderWidth="1px"
+              width="18px"
+              height="18px"
+              display="flex"
+              transition="background 0.25s ease, color 0.25s ease, border 0.25s ease"
+              transitionDelay="0.1s"
+              alignItems="center"
+              justifyContent="center"
+              borderRadius="2xl"
+              margin="8px"
+              p="xs"
+            >
+              <CheckIcon position="absolute" boxSize="9px" />
+            </Box>
+          )}
+
           {isEditable && !hovered && <ScheduleCourseSpacer />}
 
           {isOverlay && !isFromSidebar && (

--- a/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
+++ b/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
@@ -131,6 +131,8 @@ const SectionRequirement: React.FC<SidebarRequirementProps> = ({
             ...scheduleCourse,
             id: dndIdPrefix + "-" + courseKey,
           }}
+          isInSidebar
+          isChecked={false}
           isDisabled={false}
         />
       );

--- a/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
+++ b/packages/frontend-v2/components/Sidebar/SectionRequirement.tsx
@@ -132,6 +132,7 @@ const SectionRequirement: React.FC<SidebarRequirementProps> = ({
             id: dndIdPrefix + "-" + courseKey,
           }}
           isInSidebar
+          // TODO: isChecked is for when the requirement is added to the plan and validated. When true, this will render a checkmark.
           isChecked={false}
           isDisabled={false}
         />


### PR DESCRIPTION
# Description

Adds support for a checkmark to appear in a course when it's in the sidebar, if the course has been added to the plan. Added attributes "isInSidebar" and "isChecked" in `DraggableScheduleCourse` component in order to enable this.

Validation is not implemented yet! This only adds support for when validation is good to go :)

<img width="629" alt="Screenshot 2023-11-19 at 5 48 02 PM" src="https://github.com/sandboxnu/graduatenu/assets/94196677/f8343379-cc5a-48dd-a816-d30f0b62db8f">


Closes #652 

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

- Manually tested

# Checklist:

- [X] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I've run the end to end tests
- [X] Any dependent changes have been merged and published in downstream modules
