### PR TITLE
Fix default plan on page load

### DIFF
--- a/packages/frontend-v2/pages/home.tsx
+++ b/packages/frontend-v2/pages/home.tsx
@@ -93,7 +93,7 @@ const HomePage: NextPage = () => {
       if (student.plans.length > 0) {
         const sortedPlans = student.plans.sort(
           (p1, p2) =>
-            new Date(p1.updatedAt).getTime() - new Date(p2.updatedAt).getTime()
+            new Date(p2.updatedAt).getTime() - new Date(p1.updatedAt).getTime()
         );
         setSelectedPlanId(sortedPlans[0].id);
       }


### PR DESCRIPTION
# Description

On application load, we should be loading the most recently used plan. However, we currently load the last used plan due to a small logic error in our sorting. This PR simply updates the sorting algorithm to ensure that we use the last modified plan.

Closes #673

## Type of change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

1. Ensure that you have 2 plans loaded
2. Update plan A, refresh the page and plan A should be the default plan loaded upon refresh
3. Make a change to plan B, refresh the page and plan B should be the default plan loaded upon refresh.

# Checklist:

- [x] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
