### PR TITLE
Fix bug with adding a transfer course without a fullname

### DIFF
--- a/packages/common/src/api-dtos.ts
+++ b/packages/common/src/api-dtos.ts
@@ -84,7 +84,6 @@ export class SignUpStudentDto {
 }
 export class UpdateStudentDto {
   @IsOptional()
-  @IsNotEmpty()
   @IsString()
   fullName?: string;
 


### PR DESCRIPTION
# Description

Previously, we would check if the user has a fullname when updating. When we made the change to allow users to not have a fullname, it would error in our backend. This PR just removes that check.
This means that previously, a user with an empty fullname could not add a new transfer course.

Closes #680

## Type of change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Users without fullname can now add transfer courses.

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
