### PR TITLE
Make Error Boundary Home Link Domain-Agnostic

### DIFF
--- a/packages/frontend-v2/components/Error/ClientSideError.tsx
+++ b/packages/frontend-v2/components/Error/ClientSideError.tsx
@@ -35,11 +35,7 @@ export const ClientSideError: React.FC = () => {
               Sorry! We are unable to retrieve the information you need.
             </Text>
             <GraduateButtonLink
-              href={
-                process.env.NODE_ENV == "development"
-                  ? "http://localhost:3002/home"
-                  : "https://graduatenu.com/home"
-              }
+              href="/home"
               mt="md"
               variant="solid"
               borderRadius="lg"


### PR DESCRIPTION
# Description

Quick fix to make the error boundary redirect to `/home` regardless of the current domain.

Closes #682.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually locally.

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules