### PR TITLE
Add a confirmation modal when deleting a year

### DIFF
--- a/packages/frontend/components/Plan/DeleteYearModal.tsx
+++ b/packages/frontend/components/Plan/DeleteYearModal.tsx
@@ -1,0 +1,107 @@
+import { DeleteIcon } from "@chakra-ui/icons";
+import {
+  Button,
+  Flex,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { API } from "@graduate/api-client";
+import { useRouter } from "next/router";
+import { Dispatch, SetStateAction, useContext } from "react";
+import { mutate } from "swr";
+import {
+  USE_STUDENT_WITH_PLANS_SWR_KEY,
+  useStudentWithPlans,
+} from "../../hooks";
+import { handleApiClientError, toast } from "../../utils";
+import { IsGuestContext } from "../../pages/_app";
+import { GraduateToolTip } from "../GraduateTooltip";
+
+interface DeleteYearModalProps {
+  yearNum: number;
+  removeYear: Dispatch<SetStateAction<number | undefined | null>>;
+}
+export const DeleteYearModal: React.FC<DeleteYearModalProps> = ({
+  yearNum,
+  removeYear,
+}) => {
+  const router = useRouter();
+  const { onOpen, onClose, isOpen } = useDisclosure();
+  const { isGuest } = useContext(IsGuestContext);
+  const { student } = useStudentWithPlans();
+
+  if (!student) {
+    return <></>;
+  }
+
+  const deleteYear = async () => {
+    try {
+      // refresh the cache, show success message, and close the modal
+      mutate(USE_STUDENT_WITH_PLANS_SWR_KEY);
+      //   setSelectedPlanId(null);
+      removeYear(yearNum);
+      toast.success("Year deleted successfully.");
+      onClose();
+    } catch (error) {
+      handleApiClientError(error as Error, router);
+    }
+  };
+
+  return (
+    <>
+      <GraduateToolTip label={`Delete Year ${yearNum}?`} fontSize="md">
+        <IconButton
+          aria-label="Delete course"
+          variant="ghost"
+          color="white"
+          icon={<DeleteIcon />}
+          marginLeft="auto"
+          marginRight="sm"
+          _hover={{ bg: "white", color: "primary.red.main" }}
+          _active={{ bg: "primary.blue.light.900" }}
+          onClick={onOpen}
+        />
+      </GraduateToolTip>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader textAlign="center" color="primary.blue.dark.main">
+            Delete Plan
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            Woah, are you sure you want to delete Year {yearNum}?
+          </ModalBody>
+          <ModalFooter justifyContent="center">
+            <Flex columnGap="sm">
+              <Button
+                variant="solidWhite"
+                size="md"
+                borderRadius="lg"
+                onClick={onClose}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="solid"
+                size="md"
+                borderRadius="lg"
+                type="submit"
+                onClick={deleteYear}
+              >
+                Delete
+              </Button>
+            </Flex>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/packages/frontend/components/Plan/DeleteYearModal.tsx
+++ b/packages/frontend/components/Plan/DeleteYearModal.tsx
@@ -40,10 +40,9 @@ export const DeleteYearModal: React.FC<DeleteYearModalProps> = ({
 
   const deleteYear = async () => {
     try {
+      removeYear(yearNum);
       // refresh the cache, show success message, and close the modal
       mutate(USE_STUDENT_WITH_PLANS_SWR_KEY);
-      //   setSelectedPlanId(null);
-      removeYear(yearNum);
       toast.success("Year deleted successfully.");
       onClose();
     } catch (error) {

--- a/packages/frontend/components/Plan/DeleteYearModal.tsx
+++ b/packages/frontend/components/Plan/DeleteYearModal.tsx
@@ -12,16 +12,14 @@ import {
   ModalOverlay,
   useDisclosure,
 } from "@chakra-ui/react";
-import { API } from "@graduate/api-client";
 import { useRouter } from "next/router";
-import { Dispatch, SetStateAction, useContext } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { mutate } from "swr";
 import {
   USE_STUDENT_WITH_PLANS_SWR_KEY,
   useStudentWithPlans,
 } from "../../hooks";
 import { handleApiClientError, toast } from "../../utils";
-import { IsGuestContext } from "../../pages/_app";
 import { GraduateToolTip } from "../GraduateTooltip";
 
 interface DeleteYearModalProps {
@@ -34,7 +32,6 @@ export const DeleteYearModal: React.FC<DeleteYearModalProps> = ({
 }) => {
   const router = useRouter();
   const { onOpen, onClose, isOpen } = useDisclosure();
-  const { isGuest } = useContext(IsGuestContext);
   const { student } = useStudentWithPlans();
 
   if (!student) {

--- a/packages/frontend/components/Plan/ScheduleYear.tsx
+++ b/packages/frontend/components/Plan/ScheduleYear.tsx
@@ -1,4 +1,4 @@
-import { DeleteIcon, WarningIcon } from "@chakra-ui/icons";
+import { WarningIcon } from "@chakra-ui/icons";
 import { Flex, Grid, IconButton, Text, Tooltip } from "@chakra-ui/react";
 import {
   ScheduleCourse2,
@@ -8,8 +8,8 @@ import {
 } from "@graduate/common";
 import { ScheduleTerm } from "./ScheduleTerm";
 import { useState, useEffect } from "react";
-import { GraduateToolTip } from "../GraduateTooltip";
 import { totalCreditsInYear } from "../../utils";
+import { DeleteYearModal } from "./DeleteYearModal";
 
 interface ToggleYearProps {
   isExpanded: boolean;
@@ -192,23 +192,10 @@ const YearHeader: React.FC<YearHeaderProps> = ({
             />
           </Tooltip>
         )}
-        <GraduateToolTip label={`Delete year ${year.year}?`}>
-          <IconButton
-            aria-label="Delete course"
-            variant="ghost"
-            color="white"
-            icon={<DeleteIcon />}
-            marginLeft="auto"
-            marginRight="sm"
-            _hover={{ bg: "white", color: "primary.red.main" }}
-            _active={{ bg: "primary.blue.light.900" }}
-            onClick={(e) => {
-              // important to prevent the click from propogating upwards and triggering the toggle
-              e.stopPropagation();
-              removeYearFromCurrPlan();
-            }}
-          />
-        </GraduateToolTip>
+        <DeleteYearModal
+          yearNum={year.year}
+          removeYear={removeYearFromCurrPlan}
+        />
       </Flex>
     </Flex>
   );

--- a/packages/frontend/hooks/useRedirectIfLoggedIn.ts
+++ b/packages/frontend/hooks/useRedirectIfLoggedIn.ts
@@ -15,22 +15,21 @@ export const useRedirectIfLoggedIn = () => {
   const [renderSpinner, setRenderSpinner] = useState(false);
   const { setIsGuest } = useContext(IsGuestContext);
 
-  const loginWithCookie = async () => {
-    setRenderSpinner(true);
-    try {
-      await API.student.getMe();
-      setIsGuest(false);
-      router.push("/home");
-    } catch (err) {
-      const error = err as AxiosError;
-      logger.error(error);
-      setRenderSpinner(false);
-    }
-  };
-
   useEffect(() => {
+    const loginWithCookie = async () => {
+      setRenderSpinner(true);
+      try {
+        await API.student.getMe();
+        setIsGuest(false);
+        router.push("/home");
+      } catch (err) {
+        const error = err as AxiosError;
+        logger.error(error);
+        setRenderSpinner(false);
+      }
+    };
     loginWithCookie();
-  }, []);
+  }, [setIsGuest]);
 
   return renderSpinner;
 };


### PR DESCRIPTION
# Description

When deleting a year, a modal opens for the user to confirm whether they want the year to be deleted.

https://github.com/sandboxnu/graduatenu/assets/30753067/645be1e1-c8f2-4230-8842-c86bdcfc3362

Closes #685 

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Tested manually for account users and guests.

# Checklist:

- [x] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
