### PR TITLE
Prevent delete year modal from expanding year

### DIFF
--- a/packages/frontend/components/Plan/DeleteYearModal.tsx
+++ b/packages/frontend/components/Plan/DeleteYearModal.tsx
@@ -62,7 +62,10 @@ export const DeleteYearModal: React.FC<DeleteYearModalProps> = ({
           marginRight="sm"
           _hover={{ bg: "white", color: "primary.red.main" }}
           _active={{ bg: "primary.blue.light.900" }}
-          onClick={onOpen}
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpen();
+          }}
         />
       </GraduateToolTip>
       <Modal isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
# Description

Prevented the delete year modal button from trigging the expansion of the year pane. Before, the onClick event on the delete button triggered the expansion of its year. This is not fixed and clicking the delete button does not expand the year.

Closes #693 

https://github.com/sandboxnu/graduatenu/assets/30753067/90f07df3-6f35-489b-ba28-c7b7407ce883

## Type of change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
