### PR TITLE
Disable major select when year is not selected

### DIFF
--- a/packages/frontend-v2/components/Form/Select.tsx
+++ b/packages/frontend-v2/components/Form/Select.tsx
@@ -23,6 +23,7 @@ type PlanSelectProps = {
   /** Are the field values numbers. */
   isNumeric?: boolean;
   isSearchable?: boolean;
+  isDisabled?: boolean;
   /** An option in the select dropdown that indicates "no selection". */
   noValueOptionLabel?: string;
 };
@@ -37,6 +38,7 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   rules,
   isNumeric,
   isSearchable,
+  isDisabled,
   noValueOptionLabel,
 }) => {
   const {
@@ -89,6 +91,7 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
         onChange={onChange}
         value={selectedOption}
         isSearchable={isSearchable}
+        isDisabled={isDisabled}
         defaultValue={noValueOption}
         {...fieldRest}
       />

--- a/packages/frontend-v2/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend-v2/components/Plan/AddPlanModal.tsx
@@ -243,8 +243,8 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                         setValue("concentration", "");
                       }}
                       rules={{ required: "Major is required." }}
-                      helperText='First select your catalog year. If you still cannot find your major, select "No Major" above.'
                       isSearchable
+                      isDisabled={!!!catalogYear}
                     />
                     <PlanConcentrationsSelect
                       catalogYear={catalogYear}

--- a/packages/frontend-v2/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend-v2/components/Plan/EditPlanModal.tsx
@@ -268,6 +268,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                       }}
                       rules={{ required: "Major is required." }}
                       isSearchable
+                      isDisabled={!!!catalogYear}
                     />
                     <PlanConcentrationsSelect
                       catalogYear={catalogYear}


### PR DESCRIPTION
# Description

Closes #694. When creating a new plan, disable the major select when the user hasn't selected the year yet. Also removed the helper text since that is explained through the UI now.

https://github.com/sandboxnu/graduatenu/assets/92692008/0918024f-c19d-4a7c-9c9a-19bd4ac43525


## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [X] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
