### PR TITLE
Select use placeholder instead of noValueOptionLabel

### DIFF
--- a/packages/frontend-v2/components/Form/Select.tsx
+++ b/packages/frontend-v2/components/Form/Select.tsx
@@ -23,8 +23,8 @@ type PlanSelectProps = {
   /** Are the field values numbers. */
   isNumeric?: boolean;
   isSearchable?: boolean;
-  /** An option in the select dropdown that indicates "no selection". */
-  noValueOptionLabel?: string;
+  /** The default text shown in the input box. */
+  placeholder?: string;
 };
 
 export const PlanSelect: React.FC<PlanSelectProps> = ({
@@ -37,7 +37,7 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   rules,
   isNumeric,
   isSearchable,
-  noValueOptionLabel,
+  placeholder,
 }) => {
   const {
     field: { onChange: onChangeUpdateValue, value, ...fieldRest },
@@ -48,12 +48,6 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
     value: val,
     label: val,
   }));
-
-  let noValueOption;
-  if (noValueOptionLabel) {
-    noValueOption = { value: null, label: noValueOptionLabel };
-    selectOptions.unshift(noValueOption);
-  }
 
   const onChange = (option: any) => {
     let val = option ? option.value : null;
@@ -70,9 +64,9 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   if (isNumeric) {
     selectedValue = value ? value.toString() : null;
   }
-  const selectedOption =
-    selectOptions.find((option: any) => option.value === selectedValue) ??
-    noValueOption;
+  const selectedOption = selectOptions.find(
+    (option: any) => option.value === selectedValue
+  );
 
   return (
     <FormControl isInvalid={error != null}>
@@ -89,7 +83,7 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
         onChange={onChange}
         value={selectedOption}
         isSearchable={isSearchable}
-        defaultValue={noValueOption}
+        placeholder={placeholder}
         {...fieldRest}
       />
       {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/packages/frontend-v2/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend-v2/components/Plan/AddPlanModal.tsx
@@ -199,7 +199,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                   <>
                     <PlanSelect
                       label="Catalog Year"
-                      noValueOptionLabel="Select a Catalog Year"
+                      placeholder="Select a Catalog Year"
                       name="catalogYear"
                       control={control}
                       options={extractSupportedMajorYears(supportedMajorsData)}
@@ -232,7 +232,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                     />
                     <PlanSelect
                       label="Major"
-                      noValueOptionLabel="Select a Major"
+                      placeholder="Select a Major"
                       name="major"
                       control={control}
                       options={extractSupportedMajorNames(

--- a/packages/frontend-v2/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend-v2/components/Plan/EditPlanModal.tsx
@@ -225,7 +225,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                   <>
                     <PlanSelect
                       label="Catalog Year"
-                      noValueOptionLabel="Select a Catalog Year"
+                      placeholder="Select a Catalog Year"
                       name="catalogYear"
                       control={control}
                       options={extractSupportedMajorYears(supportedMajorsData)}
@@ -256,7 +256,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                     />
                     <PlanSelect
                       label="Major"
-                      noValueOptionLabel="Select a Major"
+                      placeholder="Select a Major"
                       name="major"
                       control={control}
                       options={extractSupportedMajorNames(

--- a/packages/frontend-v2/components/Plan/PlanConcentrationsSelect.tsx
+++ b/packages/frontend-v2/components/Plan/PlanConcentrationsSelect.tsx
@@ -24,8 +24,8 @@ export const PlanConcentrationsSelect: React.FC<
 
   return (
     <PlanSelect
-      label="Concentrations"
-      noValueOptionLabel="Select a Concentration"
+      label="Concentration"
+      placeholder="Select a Concentration"
       name="concentration"
       options={supportedMajor.concentrations}
       control={control}


### PR DESCRIPTION
# Description

Closes #696 

Use react-select's placeholder attribute which lets you set placeholder text that is gray instead of black. Replaced noValueOptionLabel with placeholder which also removes the default value option from the list.


https://github.com/sandboxnu/graduatenu/assets/92692008/19ea19e4-3d82-4077-8f19-5b095e5d45cd



## Type of change

Please tick the boxes that best match your changes.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
