### PR TITLE
Select use placeholder

### DIFF
--- a/packages/frontend/components/Form/Select.tsx
+++ b/packages/frontend/components/Form/Select.tsx
@@ -25,8 +25,8 @@ type PlanSelectProps = {
   /** Are the field values numbers. */
   isNumeric?: boolean;
   isSearchable?: boolean;
-  /** An option in the select dropdown that indicates "no selection". */
-  noValueOptionLabel?: string;
+  /** The default text shown in the input box. */
+  placeholder?: string;
   /** Fuzzy options to use */
   useFuzzySearch?: boolean;
 };
@@ -41,7 +41,7 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   rules,
   isNumeric,
   isSearchable,
-  noValueOptionLabel,
+  placeholder,
   useFuzzySearch,
 }) => {
   const filterOptions = useFuzzySearch
@@ -73,12 +73,6 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
     label: val,
   }));
 
-  let noValueOption;
-  if (noValueOptionLabel) {
-    noValueOption = { value: null, label: noValueOptionLabel };
-    selectOptions.unshift(noValueOption);
-  }
-
   const onChange = (option: any) => {
     let val = option ? option.value : null;
     onChangeSideEffect && onChangeSideEffect(val);
@@ -94,9 +88,16 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   if (isNumeric) {
     selectedValue = value ? value.toString() : null;
   }
-  const selectedOption =
-    selectOptions.find((option: any) => option.value === selectedValue) ??
-    noValueOption;
+  const selectedOption = selectOptions.find(
+    (option: any) => option.value === selectedValue
+  );
+
+  const styles = {
+    control: (baseStyles: any, state: { isFocused: any }) => ({
+      ...baseStyles,
+      borderColor: state.isFocused ? "neutral.200" : "neutral.100",
+    }),
+  };
 
   return (
     <FormControl isInvalid={error != null}>
@@ -109,11 +110,12 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
         {label}
       </FormLabel>
       <Select
+        styles={styles}
         options={selectOptions}
         onChange={onChange}
         value={selectedOption}
         isSearchable={isSearchable}
-        defaultValue={noValueOption}
+        placeholder={placeholder}
         filterOption={filterOptions}
         {...fieldRest}
       />

--- a/packages/frontend/components/Form/Select.tsx
+++ b/packages/frontend/components/Form/Select.tsx
@@ -93,9 +93,13 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
   );
 
   const styles = {
-    control: (baseStyles: any, state: { isFocused: any }) => ({
+    control: (baseStyles: any) => ({
       ...baseStyles,
-      borderColor: state.isFocused ? "neutral.200" : "neutral.100",
+      borderColor: "#e7ebf1",
+    }),
+    dropdownIndicator: (baseStyles: any, state: { isFocused: any }) => ({
+      ...baseStyles,
+      color: state.isFocused ? "#7586a0" : "#b4bbc8",
     }),
   };
 

--- a/packages/frontend/components/Form/Select.tsx
+++ b/packages/frontend/components/Form/Select.tsx
@@ -97,10 +97,6 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
       ...baseStyles,
       borderColor: "#e7ebf1",
     }),
-    dropdownIndicator: (baseStyles: any, state: { isFocused: any }) => ({
-      ...baseStyles,
-      color: state.isFocused ? "#7586a0" : "#b4bbc8",
-    }),
   };
 
   return (

--- a/packages/frontend/components/Form/Select.tsx
+++ b/packages/frontend/components/Form/Select.tsx
@@ -92,13 +92,6 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
     (option: any) => option.value === selectedValue
   );
 
-  const styles = {
-    control: (baseStyles: any) => ({
-      ...baseStyles,
-      borderColor: "#e7ebf1",
-    }),
-  };
-
   return (
     <FormControl isInvalid={error != null}>
       <FormLabel
@@ -110,7 +103,6 @@ export const PlanSelect: React.FC<PlanSelectProps> = ({
         {label}
       </FormLabel>
       <Select
-        styles={styles}
         options={selectOptions}
         onChange={onChange}
         value={selectedOption}

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -199,7 +199,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                   <>
                     <PlanSelect
                       label="Catalog Year"
-                      noValueOptionLabel="Select a Catalog Year"
+                      placeholder="Select a Catalog Year"
                       name="catalogYear"
                       control={control}
                       options={extractSupportedMajorYears(supportedMajorsData)}
@@ -232,7 +232,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                     />
                     <PlanSelect
                       label="Major"
-                      noValueOptionLabel="Select a Major"
+                      placeholder="Select a Major"
                       name="major"
                       control={control}
                       options={extractSupportedMajorNames(

--- a/packages/frontend/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend/components/Plan/EditPlanModal.tsx
@@ -225,7 +225,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                   <>
                     <PlanSelect
                       label="Catalog Year"
-                      noValueOptionLabel="Select a Catalog Year"
+                      placeholder="Select a Catalog Year"
                       name="catalogYear"
                       control={control}
                       options={extractSupportedMajorYears(supportedMajorsData)}
@@ -256,7 +256,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                     />
                     <PlanSelect
                       label="Major"
-                      noValueOptionLabel="Select a Major"
+                      placeholder="Select a Major"
                       name="major"
                       control={control}
                       options={extractSupportedMajorNames(

--- a/packages/frontend/components/Plan/PlanConcentrationsSelect.tsx
+++ b/packages/frontend/components/Plan/PlanConcentrationsSelect.tsx
@@ -24,8 +24,8 @@ export const PlanConcentrationsSelect: React.FC<
 
   return (
     <PlanSelect
-      label="Concentrations"
-      noValueOptionLabel="Select a Concentration"
+      label="Concentration"
+      placeholder="Select a Concentration"
       name="concentration"
       options={supportedMajor.concentrations}
       control={control}


### PR DESCRIPTION
# Description

Closes #696 

Use react-select's placeholder attribute which lets you set placeholder text that is gray instead of black. Replaced noValueOptionLabel with placeholder which also removes the default value option from the list.

Other minor changes:
- Concentrations -> Concentration
- Tweaked colors of select dropdown to match input box

Before:

https://github.com/sandboxnu/graduatenu/assets/92692008/95716e7d-524c-4821-9b9c-6b9dd74c3fcc


After:

https://github.com/sandboxnu/graduatenu/assets/92692008/66f4ec1a-0a29-4799-98ee-6b2777b7aa4f



## Type of change

Please tick the boxes that best match your changes.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [X] I have performed a self-review of my own code
- [X] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
