### PR TITLE
Add coachmark (Welcome Wagon)

### DIFF
--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -182,7 +182,6 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
 
   const disableButton = isGuest && getLocalPlansLength() > 4;
   const showCoachMark = !selectedPlanId && !isOpen;
-  // const disableButton = true;
 
   return (
     <>

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -14,6 +14,7 @@ import {
   ModalOverlay,
   VStack,
   useDisclosure,
+  Tooltip,
 } from "@chakra-ui/react";
 import { API } from "@graduate/api-client";
 import {
@@ -48,10 +49,12 @@ import { getLocalPlansLength } from "../../utils/plan/getLocalPlansLength";
 
 interface AddPlanModalProps {
   setSelectedPlanId: Dispatch<SetStateAction<number | undefined | null>>;
+  selectedPlanId: number | undefined | null;
 }
 
 export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   setSelectedPlanId,
+  selectedPlanId,
 }) => {
   const router = useRouter();
   const { onOpen, onClose: onCloseDisplay, isOpen } = useDisclosure();
@@ -178,6 +181,8 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   );
 
   const disableButton = isGuest && getLocalPlansLength() > 4;
+  const showCoachMark = !selectedPlanId && !isOpen;
+  // const disableButton = true;
 
   return (
     <>
@@ -186,15 +191,26 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
         shouldWrapChildren
         isDisabled={!disableButton}
       >
-        <BlueButton
-          leftIcon={<AddIcon />}
-          onClick={onOpen}
-          ml="xs"
-          size="md"
-          disabled={disableButton}
+        <Tooltip
+          shouldWrapChildren
+          label="Click here to start!"
+          hasArrow
+          fontSize="md"
+          borderRadius="sm"
+          shadow="lg"
+          isDisabled
+          isOpen={showCoachMark}
         >
-          New Plan
-        </BlueButton>
+          <BlueButton
+            leftIcon={<AddIcon />}
+            onClick={onOpen}
+            ml="xs"
+            size="md"
+            disabled={disableButton}
+          >
+            New Plan
+          </BlueButton>
+        </Tooltip>
       </GraduateToolTip>
       <Modal isOpen={isOpen} onClose={() => onCloseAddPlanModal()} size="md">
         <ModalOverlay />

--- a/packages/frontend/pages/home.tsx
+++ b/packages/frontend/pages/home.tsx
@@ -277,7 +277,10 @@ const HomePage: NextPage = () => {
                 setSelectedPlanId={setSelectedPlanId}
                 plans={student.plans}
               />
-              <AddPlanModal setSelectedPlanId={setSelectedPlanId} />
+              <AddPlanModal
+                setSelectedPlanId={setSelectedPlanId}
+                selectedPlanId={selectedPlanId}
+              />
               {selectedPlan && <EditPlanModal plan={selectedPlan} />}
               {selectedPlan && (
                 <DuplicatePlanButton


### PR DESCRIPTION
# Description

Adds a coachmark when no plan is selected. The coachmark will only show when no plan is selected, and closes when the add course modal opens up.

<img width="1680" alt="image" src="https://github.com/sandboxnu/graduatenu/assets/20124104/8dc9a4f4-72f8-433a-85d7-d4ec7c7741fc">


Closes #712

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Tested by running localhost

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
