### PR TITLE
Remove heads up warning for no major

### DIFF
--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -258,6 +258,7 @@ export const NoMajorSidebar: React.FC<NoMajorSidebarProps> = ({
       title="No Major"
       creditsTaken={creditsTaken}
       renderCoopBlock
+      renderDropdownWarning={false}
     >
       <Stack px="md">
         <Text>
@@ -290,6 +291,7 @@ interface SidebarContainerProps {
   creditsToTake?: number;
   renderCoopBlock?: boolean;
   renderBetaMajorBlock?: boolean;
+  renderDropdownWarning?: boolean;
 }
 
 export const NoPlanSidebar: React.FC = () => {
@@ -303,6 +305,7 @@ const SidebarContainer: React.FC<PropsWithChildren<SidebarContainerProps>> = ({
   creditsToTake,
   renderCoopBlock,
   renderBetaMajorBlock,
+  renderDropdownWarning = true,
   children,
 }) => {
   return (
@@ -347,7 +350,7 @@ const SidebarContainer: React.FC<PropsWithChildren<SidebarContainerProps>> = ({
             </Text>
           )}
         </Box>
-        <DropdownWarning />
+        {renderDropdownWarning && <DropdownWarning />}
         {creditsTaken !== undefined && (
           <Flex mb="sm" alignItems="baseline" columnGap="xs">
             <Text


### PR DESCRIPTION
# Description

Dont show the heads up dropdown if for no major plans.

<img width="1440" alt="Screenshot 2024-04-11 at 6 43 07 PM" src="https://github.com/sandboxnu/graduatenu/assets/92692008/2cc5356e-1bc6-4eb4-b2ca-1712b714db4e">

<img width="1440" alt="Screenshot 2024-04-11 at 6 43 21 PM" src="https://github.com/sandboxnu/graduatenu/assets/92692008/4932a3d5-8633-450b-a5e3-e7d5f598a525">

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
