### PR TITLE
Transfer credits now add up to total credits on sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ GraduateNU aims to empower Northeastern students to customize their plan of stud
 
 5. Then run the new version of the application by running `yarn dev` at the root of the project. This starts up a NestJS server + a NextJS frontend + a Proxy. The proxy listens on port [3002](http://localhost:3002/), forwards /api requests to the NestJS server running on port 3001, and all other requests to the frontend running on port 3000.
 
+5a. For Windows machines, run `yarn concurrently "yarn workspaces foreach --parallel --verbose --interlaced run dev" "yarn dev:proxy"` instead of `yarn dev`
+
 6. Visit [http://localhost:3002](http://localhost:3002/) to view the app.
 
 To run the two separately, visit the frontend and api packages(sub directories of the monorepo).

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -190,7 +190,13 @@ const Sidebar: React.FC<SidebarProps> = memo(
       concentrationValidationStatus = SidebarValidationStatus.Error;
     }
 
-    const creditsTaken = totalCreditsInSchedule(selectedPlan.schedule);
+    const transferCredits = transferCourses.reduce(
+      (sum, course) => course.numCreditsMin + sum,
+      0
+    );
+
+    const creditsTaken =
+      totalCreditsInSchedule(selectedPlan.schedule) + transferCredits;
 
     return (
       <SidebarContainer
@@ -247,12 +253,19 @@ const Sidebar: React.FC<SidebarProps> = memo(
 
 interface NoMajorSidebarProps {
   selectedPlan: PlanModel<string>;
+  transferCourses: ScheduleCourse2<unknown>[];
 }
 
 export const NoMajorSidebar: React.FC<NoMajorSidebarProps> = ({
   selectedPlan,
+  transferCourses,
 }) => {
-  const creditsTaken = totalCreditsInSchedule(selectedPlan.schedule);
+  const transferCredits = transferCourses.reduce(
+    (sum, course) => course.numCreditsMin + sum,
+    0
+  );
+  const creditsTaken =
+    totalCreditsInSchedule(selectedPlan.schedule) + transferCredits;
   return (
     <SidebarContainer
       title="No Major"

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -190,13 +190,10 @@ const Sidebar: React.FC<SidebarProps> = memo(
       concentrationValidationStatus = SidebarValidationStatus.Error;
     }
 
-    const transferCredits = transferCourses.reduce(
-      (sum, course) => course.numCreditsMin + sum,
-      0
+    const creditsTaken = totalCreditsInSchedule(
+      selectedPlan.schedule,
+      transferCourses
     );
-
-    const creditsTaken =
-      totalCreditsInSchedule(selectedPlan.schedule) + transferCredits;
 
     return (
       <SidebarContainer
@@ -260,12 +257,10 @@ export const NoMajorSidebar: React.FC<NoMajorSidebarProps> = ({
   selectedPlan,
   transferCourses,
 }) => {
-  const transferCredits = transferCourses.reduce(
-    (sum, course) => course.numCreditsMin + sum,
-    0
+  const creditsTaken = totalCreditsInSchedule(
+    selectedPlan.schedule,
+    transferCourses
   );
-  const creditsTaken =
-    totalCreditsInSchedule(selectedPlan.schedule) + transferCredits;
   return (
     <SidebarContainer
       title="No Major"

--- a/packages/frontend/pages/home.tsx
+++ b/packages/frontend/pages/home.tsx
@@ -249,7 +249,13 @@ const HomePage: NextPage = () => {
           transferCourses={student.coursesTransfered || []}
         />
       );
-    } else renderedSidebar = <NoMajorSidebar selectedPlan={selectedPlan} />;
+    } else
+      renderedSidebar = (
+        <NoMajorSidebar
+          selectedPlan={selectedPlan}
+          transferCourses={student.coursesTransfered || []}
+        />
+      );
   }
 
   return (

--- a/packages/frontend/utils/plan/totalCredits.ts
+++ b/packages/frontend/utils/plan/totalCredits.ts
@@ -1,4 +1,9 @@
-import { Schedule2, ScheduleTerm2, ScheduleYear2 } from "@graduate/common";
+import {
+  Schedule2,
+  ScheduleCourse2,
+  ScheduleTerm2,
+  ScheduleYear2,
+} from "@graduate/common";
 
 /** The credits for all courses in a term. */
 export const totalCreditsInTerm = (term: ScheduleTerm2<unknown>): number => {
@@ -23,12 +28,14 @@ export const totalCreditsInYear = (
 
 /** The credits for all courses in a schedule summed. */
 export const totalCreditsInSchedule = (
-  schedule: Schedule2<unknown>
+  schedule: Schedule2<unknown>,
+  transfer: ScheduleCourse2<unknown>[]
 ): number => {
   return (
-    schedule.years.reduce(
+    (schedule.years.reduce(
       (totalCredits, year) => totalCreditsInYear(year) + totalCredits,
       0
-    ) ?? 0
+    ) ?? 0) +
+    (transfer.reduce((sum, course) => course.numCreditsMin + sum, 0) ?? 0)
   );
 };


### PR DESCRIPTION
# Description

Shireen and I added the function to calculate the total amount of transfer credit on both types of sidebars (major and non-major). We changed the parameters to take in transferCourses on the non-major sidebar. The function calculates the sum and adds it to the totalCreditsInSchedule to get creditsTaken. 

For the future, maybe add AP courses on the "Add transfer courses" modal so the user doesn't have to look up the AP to NEU course transfer policies.

![image](https://github.com/user-attachments/assets/b1d6611d-c6bc-4553-b90d-b71cf1deb8e8)


Closes # (issue number)

## Type of change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
