### PR TITLE
added link to  all draggable courses

### DIFF
--- a/packages/frontend/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend/components/ScheduleCourse/ScheduleCourse.tsx
@@ -7,6 +7,7 @@ import {
   INEUReqError,
   IRequiredCourse,
   ScheduleCourse2,
+  SeasonEnum,
 } from "@graduate/common";
 import { forwardRef, PropsWithChildren, useEffect, useState } from "react";
 import {
@@ -370,6 +371,17 @@ const ScheduleCourseDraggedContents: React.FC<
             {`${courseToString(scheduleCourse)} `}
           </span>
           <span>{scheduleCourse.name}</span>
+          <br></br>
+          {scheduleCourse != null && (
+            <a //hehe year and season hardcoded :D how to get course context?
+              href={getSearchLink(2022, SeasonEnum.FL, scheduleCourse)}
+              style={{ textDecorationLine: "underline" }}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Find on NUSearch!
+            </a>
+          )}
         </p>
       </div>
     </div>
@@ -383,3 +395,33 @@ const ScheduleCourseDraggedContents: React.FC<
 const ScheduleCourseSpacer: React.FC = () => {
   return <div style={{ width: "32px", height: "32px", flexShrink: 0 }}></div>;
 };
+
+function getSearchLink(
+  catalogYear: number,
+  szn: SeasonEnum,
+  course: ScheduleCourse2<unknown>
+): string {
+  let sznInt = -1;
+  switch (szn) {
+    case SeasonEnum.FL:
+      sznInt = 1;
+      break;
+    case SeasonEnum.SP:
+      sznInt = 3;
+      break;
+    case SeasonEnum.S1:
+      sznInt = 4;
+      break;
+    case SeasonEnum.SM:
+      sznInt = 5;
+      break;
+    case SeasonEnum.S2:
+      sznInt = 6;
+      break;
+    default:
+      sznInt = 1;
+  }
+  return `https://searchneu.com/NEU/${catalogYear}${sznInt}${0}/search/${
+    course.subject
+  }${course.classId}`;
+}


### PR DESCRIPTION
# Description

I added a link to all draggable courses that lead to their search page. The season and year values are hardcoded in. The fact that the course objects are draggable also makes the links un-left-clickable and needs to be right clicked>open in new tab to open.


## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/99200daf-acc2-4327-8e14-c3663a56433e)
![image](https://github.com/user-attachments/assets/ca23b6ce-2381-4a49-8281-485ffbd1a1e4)


# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
