### PR TITLE
updated addplan modal to support empty plan name

### DIFF
--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -145,7 +145,6 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
     onCloseDisplay();
   };
 
-  const title = watch("name");
   const catalogYear = watch("catalogYear");
   const majorName = watch("major");
   const concentration = watch("concentration");

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -60,6 +60,13 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   const { onOpen, onClose: onCloseDisplay, isOpen } = useDisclosure();
   const { supportedMajorsData, error: supportedMajorsError } =
     useSupportedMajors();
+
+  // Generate default plan title using formatted date and time
+  const generateDefaultPlanTitle = () => {
+    const now = new Date();
+    return `Plan ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+  };
+
   const {
     register,
     handleSubmit,
@@ -87,7 +94,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   const onSubmitHandler = async (payload: CreatePlanDtoWithoutSchedule) => {
     const schedule = createEmptySchedule();
     const newPlan: CreatePlanDto = {
-      name: payload.name,
+      name: payload.name || generateDefaultPlanTitle(),
       catalogYear: isNoMajorSelected ? undefined : payload.catalogYear,
       major: isNoMajorSelected ? undefined : payload.major,
       concentration: isNoMajorSelected ? undefined : payload.concentration,
@@ -161,13 +168,12 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
     yearSupportedMajors?.[majorName ?? ""]?.verified ?? false;
 
   const isValidForm =
-    (title &&
-      catalogYear &&
+    (catalogYear &&
       majorName &&
       (!isConcentrationRequired || concentration) &&
       (!isValidatedMajor ? agreeToBetaMajor : true)) ||
     // Valid plan for no major selected
-    (title && isNoMajorSelected);
+    isNoMajorSelected;
 
   const noMajorHelperLabel = (
     <Stack>
@@ -227,10 +233,9 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                   label="Title"
                   id="name"
                   type="text"
-                  placeholder="My Plan"
+                  placeholder={generateDefaultPlanTitle()}
                   error={errors.name}
                   {...register("name", {
-                    required: "Title is required",
                     pattern: noLeadOrTrailWhitespacePattern,
                   })}
                 />

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -62,9 +62,11 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
     useSupportedMajors();
 
   // Generate default plan title using formatted date and time
-  const generateDefaultPlanTitle = () => {
+  const generateDefaultPlanTitle = (catalogYear?: number, major?: string) => {
     const now = new Date();
-    return `Plan ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+    return `${catalogYear ? `${catalogYear} - ` : ""}${
+      major ? `${major} - ` : ""
+    }${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
   };
 
   const {
@@ -94,7 +96,9 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   const onSubmitHandler = async (payload: CreatePlanDtoWithoutSchedule) => {
     const schedule = createEmptySchedule();
     const newPlan: CreatePlanDto = {
-      name: payload.name || generateDefaultPlanTitle(),
+      name:
+        payload.name ||
+        generateDefaultPlanTitle(payload.catalogYear, payload.major),
       catalogYear: isNoMajorSelected ? undefined : payload.catalogYear,
       major: isNoMajorSelected ? undefined : payload.major,
       concentration: isNoMajorSelected ? undefined : payload.concentration,
@@ -232,7 +236,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                   label="Title"
                   id="name"
                   type="text"
-                  placeholder={generateDefaultPlanTitle()}
+                  placeholder={generateDefaultPlanTitle(catalogYear, majorName)}
                   error={errors.name}
                   {...register("name", {
                     pattern: noLeadOrTrailWhitespacePattern,

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -62,11 +62,9 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
     useSupportedMajors();
 
   // Generate default plan title using formatted date and time
-  const generateDefaultPlanTitle = (catalogYear?: number, major?: string) => {
+  const generateDefaultPlanTitle = () => {
     const now = new Date();
-    return `${catalogYear ? `${catalogYear} - ` : ""}${
-      major ? `${major} - ` : ""
-    }${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+    return `Plan ${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
   };
 
   const {
@@ -96,9 +94,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   const onSubmitHandler = async (payload: CreatePlanDtoWithoutSchedule) => {
     const schedule = createEmptySchedule();
     const newPlan: CreatePlanDto = {
-      name:
-        payload.name ||
-        generateDefaultPlanTitle(payload.catalogYear, payload.major),
+      name: payload.name || generateDefaultPlanTitle(),
       catalogYear: isNoMajorSelected ? undefined : payload.catalogYear,
       major: isNoMajorSelected ? undefined : payload.major,
       concentration: isNoMajorSelected ? undefined : payload.concentration,
@@ -236,7 +232,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                   label="Title"
                   id="name"
                   type="text"
-                  placeholder={generateDefaultPlanTitle(catalogYear, majorName)}
+                  placeholder={generateDefaultPlanTitle()}
                   error={errors.name}
                   {...register("name", {
                     pattern: noLeadOrTrailWhitespacePattern,


### PR DESCRIPTION
# Description

Updated form validation. Title is no longer required. This is because the value is set to `Plan [timestamp]` if value is empty. `Plan [timestamp]` is also placeholder value for plan. Hopefully not too expensive to get timestamp. 

EDIT 2/18: Added catalog year + major name to the default name. kept date and time to prevent repeated names. not sure if necessary.

EDIT 2/18 (1): went back to og, with timestamp, this is because if we type their major for them the title might be too long

![image](https://github.com/user-attachments/assets/f7799f71-ae1e-4aed-8bfe-6dcf51ddd3b6)


Closes #789 

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# Checklist:

- [x] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
