### PR TITLE
790 allow plans with no concentration

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
     "@nestjs/passport": "^8.1.0",
     "@nestjs/platform-express": "^9.0.5",
     "@nestjs/typeorm": "^8.0.2",
-    "bcrypt": "5.0.0",
+    "bcrypt": "5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "cookie-parser": "^1.4.6",

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -7,3 +7,5 @@
  */
 export const COOKIE_DOMAIN =
   process.env.NODE_ENV === "production" ? "graduatenu.com" : "localhost";
+
+export const UNDECIDED = "Undecided";

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -3,7 +3,7 @@ import {
   SupportedMajorsForYear,
   SupportedMajors,
   SupportedConcentrations,
-  UNDECIDED,
+  UNDECIDED_STRING,
 } from "@graduate/common";
 import { Injectable, Logger } from "@nestjs/common";
 import { formatServiceCtx } from "../utils";
@@ -123,7 +123,7 @@ export class MajorService {
 
     const isValidConcentrationName =
       concentrations.includes(concentrationName) ||
-      concentrationName === UNDECIDED;
+      concentrationName === UNDECIDED_STRING;
 
     if (!isValidConcentrationName) {
       this.logger.debug(

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -3,6 +3,7 @@ import {
   SupportedMajorsForYear,
   SupportedMajors,
   SupportedConcentrations,
+  UNDECIDED,
 } from "@graduate/common";
 import { Injectable, Logger } from "@nestjs/common";
 import { formatServiceCtx } from "../utils";

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -120,9 +120,9 @@ export class MajorService {
       return false;
     }
 
-    const isValidConcentrationName = concentrations.some(
-      (c) => c === concentrationName
-    );
+    const isValidConcentrationName =
+      concentrations.includes(concentrationName) ||
+      concentrationName.toLowerCase() === "undecided";
 
     if (!isValidConcentrationName) {
       this.logger.debug(
@@ -134,10 +134,9 @@ export class MajorService {
         },
         MajorService.formatMajorServiceCtx("isValidConcentrationForMajor")
       );
-
       return false;
     }
-
+    console.log("ASDASDSA");
     return true;
   }
 

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -4,6 +4,7 @@ import {
   SupportedMajors,
   SupportedConcentrations,
 } from "@graduate/common";
+import { UNDECIDED } from "@graduate/common/dist/constants";
 import { Injectable, Logger } from "@nestjs/common";
 import { formatServiceCtx } from "../utils";
 import { MAJOR_YEARS, MAJORS } from "./major-collator";
@@ -122,7 +123,7 @@ export class MajorService {
 
     const isValidConcentrationName =
       concentrations.includes(concentrationName) ||
-      concentrationName === "Undecided";
+      concentrationName === UNDECIDED;
 
     if (!isValidConcentrationName) {
       this.logger.debug(

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -122,7 +122,7 @@ export class MajorService {
 
     const isValidConcentrationName =
       concentrations.includes(concentrationName) ||
-      concentrationName.toLowerCase() === "undecided";
+      concentrationName === "Undecided";
 
     if (!isValidConcentrationName) {
       this.logger.debug(

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -4,7 +4,6 @@ import {
   SupportedMajors,
   SupportedConcentrations,
 } from "@graduate/common";
-import { UNDECIDED } from "@graduate/common/dist/constants";
 import { Injectable, Logger } from "@nestjs/common";
 import { formatServiceCtx } from "../utils";
 import { MAJOR_YEARS, MAJORS } from "./major-collator";

--- a/packages/api/src/major/major.service.ts
+++ b/packages/api/src/major/major.service.ts
@@ -136,7 +136,6 @@ export class MajorService {
       );
       return false;
     }
-    console.log("ASDASDSA");
     return true;
   }
 

--- a/packages/api/src/major/majors/2021/computer-information-science/computer_science_bacs/parsed.commit.json
+++ b/packages/api/src/major/majors/2021/computer-information-science/computer_science_bacs/parsed.commit.json
@@ -541,6 +541,7 @@
   ],
   "concentrations": {
     "minOptions": 1,
+
     "concentrationOptions": [
       {
         "type": "SECTION",

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -7,5 +7,5 @@ export const wrongPasswordError = "Incorrect Password";
 export const forgotPasswordTokenExpiredError = "Token expired";
 export const unableToSendEmail = "Unable to send email";
 export const emailAlreadyConfirmed = "Email already confirmed";
-export const UNDECIDED = "Undecided";
+export const UNDECIDED_STRING = "Undecided";
 export const UNDECIDED_CONCENTRATION = "Concentration Undecided";

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -8,3 +8,4 @@ export const forgotPasswordTokenExpiredError = "Token expired";
 export const unableToSendEmail = "Unable to send email";
 export const emailAlreadyConfirmed = "Email already confirmed";
 export const UNDECIDED = "Undecided";
+export const UNDECIDED_CONCENTRATION = "Concentration Undecided";

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -7,3 +7,4 @@ export const wrongPasswordError = "Incorrect Password";
 export const forgotPasswordTokenExpiredError = "Token expired";
 export const unableToSendEmail = "Unable to send email";
 export const emailAlreadyConfirmed = "Email already confirmed";
+export const UNDECIDED = "Undecided";

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -15,6 +15,7 @@ import {
   Err,
   Ok,
 } from "./types";
+import { UNDECIDED } from "./constants";
 import { assertUnreachable, courseToString } from "./course-utils";
 
 /**
@@ -403,7 +404,7 @@ export function getConcentrationsRequirement(
     return [];
   }
   // Allow undecided concentrations
-  if (inputConcentrations === "Undecided") {
+  if (inputConcentrations === UNDECIDED) {
     return [];
   }
   const concentrationRequirements = [];

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -302,7 +302,6 @@ export function validateMajor2(
 ): MajorValidationResult {
   const tracker = new Major2ValidationTracker(taken);
   let concentrationReq: Requirement2[] = [];
-  console.log(concentrations); // this is "undecided"
   if (major.concentrations) {
     concentrationReq = getConcentrationsRequirement(
       concentrations,
@@ -403,6 +402,7 @@ export function getConcentrationsRequirement(
   if (concentrationsRequirement.concentrationOptions.length === 0) {
     return [];
   }
+  // Allow undecided concentrations
   if (inputConcentrations === "Undecided") {
     return [];
   }

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -193,12 +193,19 @@ interface CourseValidationTracker {
 
   // do we have enough courses to take all classes in both solutions?
   hasEnoughCoursesForBoth(s1: Solution, s2: Solution): boolean;
+
+  setNecessaryCourses(courses: Set<string>): void;
+
+  getNecessaryCourses(): Set<string>;
 }
 
 // exported for testing
 export class Major2ValidationTracker implements CourseValidationTracker {
   // maps courseString => [course instance, # of times taken]
   private currentCourses: Map<string, [ScheduleCourse2<unknown>, number]>;
+
+  //list of degree-required courses that we should not consider in the range validator
+  private necessaryCourses: Set<string> = new Set();
 
   constructor(courses: ScheduleCourse2<unknown>[]) {
     this.currentCourses = new Map();
@@ -260,6 +267,14 @@ export class Major2ValidationTracker implements CourseValidationTracker {
     return true;
   }
 
+  setNecessaryCourses(courses: Set<string>) {
+    this.necessaryCourses = courses;
+  }
+
+  getNecessaryCourses() {
+    return this.necessaryCourses;
+  }
+
   // Maps the # of each course required in the given solution
   private static createTakenMap(s: Solution): Map<string, number> {
     const map = new Map();
@@ -295,6 +310,10 @@ export function validateMajor2(
   }
 
   const majorReqs = [...major.requirementSections, ...concentrationReq];
+
+  const requiredCourses: Set<string> = new Set();
+  tracker.setNecessaryCourses(getNecessaryCourses(majorReqs, requiredCourses));
+
   // create a big AND requirement of all the sections and selected concentrations
   const requirementsResult = validateRequirement(
     {
@@ -321,6 +340,51 @@ export function validateMajor2(
     majorRequirementsError,
     totalCreditsRequirementError,
   });
+}
+
+/**
+ * Crawls through the requirements, producing a list of necessary courses. This
+ * is used to filter out courses that cannot be used for the range.
+ */
+export function getNecessaryCourses(
+  requirements: Requirement2[],
+  requiredCourses: Set<string>
+): Set<string> {
+  const tracker = new Major2ValidationTracker([]);
+
+  for (const req of requirements) {
+    crawlRequirement(req, tracker, requiredCourses);
+  }
+  return requiredCourses;
+}
+
+/** Crawls through the requirements, producing a list of necessary courses. */
+function crawlRequirement(
+  req: Requirement2,
+  tracker: CourseValidationTracker,
+  requiredCourses: Set<string>
+): void {
+  switch (req.type) {
+    // base cases, a course is added to the list of necessary courses
+    case "COURSE":
+      requiredCourses.add(courseToString(req));
+      break;
+    // inductive case, we crawl through the children of an AND requirement
+    case "AND":
+      req.courses.forEach((r) => crawlRequirement(r, tracker, requiredCourses));
+      break;
+    // inductive case, we crawl through the children of a whole section
+    case "SECTION":
+      req.requirements.forEach((r) =>
+        crawlRequirement(r, tracker, requiredCourses)
+      );
+    case "XOM":
+    case "OR":
+    case "RANGE":
+      break;
+    default:
+      return assertUnreachable(req);
+  }
 }
 
 /**
@@ -443,6 +507,8 @@ function validateRangeRequirement(
 ): Result<Array<Solution>, MajorValidationError> {
   // get the eligible courses (Filter out exceptions)
   const exceptions = new Set(r.exceptions.map(courseToString));
+  tracker.getNecessaryCourses().forEach((course) => exceptions.add(course));
+
   const courses = tracker
     .getAll(r.subject, r.idRangeStart, r.idRangeEnd)
     .filter((c) => !exceptions.has(courseToString(c)));

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -15,7 +15,7 @@ import {
   Err,
   Ok,
 } from "./types";
-import { UNDECIDED } from "./constants";
+import { UNDECIDED_STRING } from "./constants";
 import { assertUnreachable, courseToString } from "./course-utils";
 
 /**
@@ -404,7 +404,7 @@ export function getConcentrationsRequirement(
     return [];
   }
   // Allow undecided concentrations
-  if (inputConcentrations === UNDECIDED) {
+  if (inputConcentrations === UNDECIDED_STRING) {
     return [];
   }
   const concentrationRequirements = [];

--- a/packages/common/src/major2-validation.ts
+++ b/packages/common/src/major2-validation.ts
@@ -302,6 +302,7 @@ export function validateMajor2(
 ): MajorValidationResult {
   const tracker = new Major2ValidationTracker(taken);
   let concentrationReq: Requirement2[] = [];
+  console.log(concentrations); // this is "undecided"
   if (major.concentrations) {
     concentrationReq = getConcentrationsRequirement(
       concentrations,
@@ -400,6 +401,9 @@ export function getConcentrationsRequirement(
   const selectedConcentrations =
     convertToConcentrationsArray(inputConcentrations);
   if (concentrationsRequirement.concentrationOptions.length === 0) {
+    return [];
+  }
+  if (inputConcentrations === "Undecided") {
     return [];
   }
   const concentrationRequirements = [];

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,5 +1,10 @@
 import type { OptionObject } from "./types";
 
+const UNDECIDED_OPTION: OptionObject = {
+  label: "Undecided",
+  value: "Undecided",
+};
+
 /** Does the given password satisfy our minimum criteria for strength? */
 export const isStrongPassword = (password: string): boolean => {
   const containsLettersAndNumbersRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])/;
@@ -35,30 +40,21 @@ export const majorOptionObjectComparator = (
 
 /**
  * Converts a list of strings or numbers into a list of option objects for the
- * Select component, including an "Undecided" option.
- */
-export const convertToOptionObjectsIncludingUndecided = (
-  options: (string | number)[]
-): OptionObject[] => {
-  const optionObjects = convertToOptionObjects(options);
-  optionObjects.unshift({
-    label: "Undecided",
-    value: "Undecided",
-  });
-  return optionObjects;
-};
-
-/**
- * Converts a list of strings or numbers into a list of option objects for the
  * Select component.
+ *
+ * IncludeUndecided: optional parameter specifying whether to include\
+ * "Undecided" as an option
  */
 export const convertToOptionObjects = (
-  options: (string | number)[]
+  options: (string | number)[],
+  includeUndecided = false
 ): OptionObject[] => {
-  return options.map((option) => {
-    return {
-      label: option,
-      value: option,
-    };
-  });
+  const optionObjects = options.map((option) => ({
+    label: option,
+    value: option,
+  }));
+  if (includeUndecided) {
+    optionObjects.unshift(UNDECIDED_OPTION);
+  }
+  return optionObjects;
 };

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -33,6 +33,10 @@ export const majorOptionObjectComparator = (
   return majorNameComparator(a.value.toString(), b.value.toString());
 };
 
+/**
+ * Converts a list of strings or numbers into a list of option objects for the
+ * Select component, including an "Undecided" option.
+ */
 export const convertToOptionObjectsIncludingUndecided = (
   options: (string | number)[]
 ): OptionObject[] => {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -33,6 +33,17 @@ export const majorOptionObjectComparator = (
   return majorNameComparator(a.value.toString(), b.value.toString());
 };
 
+export const convertToOptionObjectsIncludingUndecided = (
+  options: (string | number)[]
+): OptionObject[] => {
+  const optionObjects = convertToOptionObjects(options);
+  optionObjects.unshift({
+    label: "Undecided",
+    value: "Undecided",
+  });
+  return optionObjects;
+};
+
 /**
  * Converts a list of strings or numbers into a list of option objects for the
  * Select component.

--- a/packages/common/test/major2-validation.test.ts
+++ b/packages/common/test/major2-validation.test.ts
@@ -20,7 +20,7 @@ import {
   IOrCourse2,
   IRequiredCourse,
   IXofManyCourse,
-  Major2,
+  type Major2,
   Requirement2,
   ScheduleCourse2,
   Section,

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -22,7 +22,6 @@ import {
   CreatePlanDtoWithoutSchedule,
   PlanModel,
   convertToOptionObjects,
-  convertToOptionObjectsIncludingUndecided,
 } from "@graduate/common";
 import { useRouter } from "next/router";
 import { Dispatch, SetStateAction, useContext, useState } from "react";
@@ -319,8 +318,9 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                         label="Concentrations"
                         name="concentration"
                         placeholder="Select a Concentration"
-                        options={convertToOptionObjectsIncludingUndecided(
-                          majorConcentrations.concentrations
+                        options={convertToOptionObjects(
+                          majorConcentrations.concentrations,
+                          true
                         )}
                         control={control}
                         rules={{

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -22,6 +22,7 @@ import {
   CreatePlanDtoWithoutSchedule,
   PlanModel,
   convertToOptionObjects,
+  convertToOptionObjectsIncludingUndecided,
 } from "@graduate/common";
 import { useRouter } from "next/router";
 import { Dispatch, SetStateAction, useContext, useState } from "react";
@@ -93,6 +94,8 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
       concentration: isNoMajorSelected ? undefined : payload.concentration,
       schedule,
     };
+
+    console.log(newPlan, " THIS IS NEW PLAN");
 
     // create the new plan
     let createdPlanId: number;
@@ -318,7 +321,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                         label="Concentrations"
                         name="concentration"
                         placeholder="Select a Concentration"
-                        options={convertToOptionObjects(
+                        options={convertToOptionObjectsIncludingUndecided(
                           majorConcentrations.concentrations
                         )}
                         control={control}

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -95,8 +95,6 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
       schedule,
     };
 
-    console.log(newPlan, " THIS IS NEW PLAN");
-
     // create the new plan
     let createdPlanId: number;
     if (isGuest) {

--- a/packages/frontend/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend/components/Plan/EditPlanModal.tsx
@@ -20,6 +20,7 @@ import {
   PlanModel,
   UpdatePlanDto,
   convertToOptionObjects,
+  convertToOptionObjectsIncludingUndecided,
 } from "@graduate/common";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useState } from "react";
@@ -310,7 +311,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                         label="Concentrations"
                         name="concentration"
                         placeholder="Select a Concentration"
-                        options={convertToOptionObjects(
+                        options={convertToOptionObjectsIncludingUndecided(
                           majorConcentrations.concentrations
                         )}
                         control={control}

--- a/packages/frontend/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend/components/Plan/EditPlanModal.tsx
@@ -20,7 +20,6 @@ import {
   PlanModel,
   UpdatePlanDto,
   convertToOptionObjects,
-  convertToOptionObjectsIncludingUndecided,
 } from "@graduate/common";
 import { useRouter } from "next/router";
 import { useCallback, useContext, useEffect, useState } from "react";
@@ -311,8 +310,9 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                         label="Concentrations"
                         name="concentration"
                         placeholder="Select a Concentration"
-                        options={convertToOptionObjectsIncludingUndecided(
-                          majorConcentrations.concentrations
+                        options={convertToOptionObjects(
+                          majorConcentrations.concentrations,
+                          true
                         )}
                         control={control}
                         rules={{

--- a/packages/frontend/components/Plan/ErrorModalError.tsx
+++ b/packages/frontend/components/Plan/ErrorModalError.tsx
@@ -1,0 +1,70 @@
+import { ChevronDownIcon, ChevronUpIcon, WarningIcon } from "@chakra-ui/icons";
+import { Box, Flex, Text, Collapse } from "@chakra-ui/react";
+import { useState } from "react";
+
+interface ErrorModalErrorProps {
+  title: string;
+  message: string;
+}
+
+export const ErrorModalError: React.FC<ErrorModalErrorProps> = ({
+  title,
+  message,
+}) => {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <Box
+      border="1px solid"
+      borderColor="primary.red.main"
+      borderRadius="lg"
+      backgroundColor="#FAE8E7"
+      transition="background-color 0.25s ease"
+      _hover={{ backgroundColor: "#F9DAD8" }}
+    >
+      <Flex
+        onClick={() => setOpened(!opened)}
+        direction="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
+        height="45px"
+        color="black"
+        fontWeight="bold"
+        p="sm"
+        position="sticky"
+        top="0px"
+        zIndex={1}
+      >
+        <Flex direction="row" height="100%" columnGap="sm">
+          <Flex direction="row" height="100%" alignItems="center" gap="1">
+            <WarningIcon
+              color="primary.red.main"
+              width="2rem"
+              alignSelf="center"
+              alignItems="center"
+              justifySelf="center"
+              transition="background 0.15s ease"
+            />
+            <Text color="black" mt="0" fontSize="sm">
+              {title}
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Flex ml="xs" alignItems="center" justifyItems="center">
+          {opened ? (
+            <ChevronUpIcon boxSize="25px" color="primary.red.main" />
+          ) : (
+            <ChevronDownIcon boxSize="25px" color="primary.red.main" />
+          )}
+        </Flex>
+      </Flex>
+
+      <Collapse in={opened} animateOpacity>
+        <Box px="sm" py="xs" borderRadius="lg" backgroundColor="transparent">
+          <Text fontSize="sm">{message}</Text>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};

--- a/packages/frontend/components/Plan/Plan.tsx
+++ b/packages/frontend/components/Plan/Plan.tsx
@@ -7,7 +7,7 @@ import {
   ScheduleYear2,
   SeasonEnum,
 } from "@graduate/common";
-import { useState } from "react";
+import { useState, createContext } from "react";
 import { addClassesToTerm, removeYearFromPlan } from "../../utils";
 import { removeCourseFromTerm } from "../../utils";
 import { ScheduleYear } from "./ScheduleYear";
@@ -27,6 +27,7 @@ interface PlanProps {
   mutateStudentWithUpdatedPlan: (updatedPlan: PlanModel<string>) => void;
 }
 
+export const TotalYearsContext = createContext<number | null>(null);
 export const Plan: React.FC<PlanProps> = ({
   plan,
   mutateStudentWithUpdatedPlan,
@@ -35,6 +36,7 @@ export const Plan: React.FC<PlanProps> = ({
   setIsRemove,
 }) => {
   const [expandedYears, setExpandedYears] = useState<Set<number>>(new Set());
+  const totalYears = plan.schedule.years.length;
 
   const toggleExpanded = (year: ScheduleYear2<unknown>) => {
     if (expandedYears.has(year.year)) {
@@ -109,41 +111,45 @@ export const Plan: React.FC<PlanProps> = ({
   };
 
   return (
-    <Flex direction="column" rowGap="sm">
-      <Flex flexDirection="column" rowGap="4xs" ref={setNodeRef}>
-        {plan.schedule.years.map((scheduleYear) => {
-          const isExpanded = expandedYears.has(scheduleYear.year);
+    <TotalYearsContext.Provider value={totalYears}>
+      <Flex direction="column" rowGap="sm">
+        <Flex flexDirection="column" rowGap="4xs" ref={setNodeRef}>
+          {plan.schedule.years.map((scheduleYear) => {
+            const isExpanded = expandedYears.has(scheduleYear.year);
 
-          return (
-            <Flex key={scheduleYear.year} flexDirection="column">
-              <ScheduleYear
-                catalogYear={plan.catalogYear}
-                yearCoReqError={coReqErr?.years.find(
-                  (year) => year.year == scheduleYear.year
-                )}
-                yearPreReqError={preReqErr?.years.find(
-                  (year) => year.year == scheduleYear.year
-                )}
-                scheduleYear={scheduleYear}
-                isExpanded={isExpanded}
-                toggleExpanded={() => toggleExpanded(scheduleYear)}
-                addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
-                removeCourseFromTermInCurrPlan={removeCourseFromTermInCurrPlan}
-                removeYearFromCurrPlan={() =>
-                  removeYearFromCurrPlan(scheduleYear.year)
-                }
-                setIsRemove={setIsRemove}
-              />
-            </Flex>
-          );
-        })}
+            return (
+              <Flex key={scheduleYear.year} flexDirection="column">
+                <ScheduleYear
+                  catalogYear={plan.catalogYear}
+                  yearCoReqError={coReqErr?.years.find(
+                    (year) => year.year == scheduleYear.year
+                  )}
+                  yearPreReqError={preReqErr?.years.find(
+                    (year) => year.year == scheduleYear.year
+                  )}
+                  scheduleYear={scheduleYear}
+                  isExpanded={isExpanded}
+                  toggleExpanded={() => toggleExpanded(scheduleYear)}
+                  addClassesToTermInCurrPlan={addClassesToTermInCurrPlan}
+                  removeCourseFromTermInCurrPlan={
+                    removeCourseFromTermInCurrPlan
+                  }
+                  removeYearFromCurrPlan={() =>
+                    removeYearFromCurrPlan(scheduleYear.year)
+                  }
+                  setIsRemove={setIsRemove}
+                />
+              </Flex>
+            );
+          })}
+        </Flex>
+        <Flex>
+          <AddYearButton
+            plan={plan}
+            mutateStudentWithUpdatedPlan={mutateStudentWithUpdatedPlan}
+          />
+        </Flex>
       </Flex>
-      <Flex>
-        <AddYearButton
-          plan={plan}
-          mutateStudentWithUpdatedPlan={mutateStudentWithUpdatedPlan}
-        />
-      </Flex>
-    </Flex>
+    </TotalYearsContext.Provider>
   );
 };

--- a/packages/frontend/components/Plan/ScheduleTerm.tsx
+++ b/packages/frontend/components/Plan/ScheduleTerm.tsx
@@ -78,6 +78,7 @@ export const ScheduleTerm: React.FC<ScheduleTermProps> = ({
           coReqErr={termCoReqErr?.[courseToString(scheduleCourse)]}
           preReqErr={termPreReqErr?.[courseToString(scheduleCourse)]}
           scheduleCourse={scheduleCourse}
+          scheduleTerm={scheduleTerm}
           removeCourse={(course: ScheduleCourse2<unknown>) =>
             removeCourseFromTermInCurrPlan(
               course,

--- a/packages/frontend/components/Plan/index.ts
+++ b/packages/frontend/components/Plan/index.ts
@@ -5,3 +5,4 @@ export * from "./EditPlanModal";
 export * from "./DeletePlanModal";
 export * from "./AddYearButton";
 export * from "./TransferCourses";
+export * from "./ErrorModalError";

--- a/packages/frontend/components/ScheduleCourse/ScheduleCourse.tsx
+++ b/packages/frontend/components/ScheduleCourse/ScheduleCourse.tsx
@@ -7,11 +7,20 @@ import {
   INEUReqError,
   IRequiredCourse,
   ScheduleCourse2,
+  ScheduleTerm2,
   SeasonEnum,
 } from "@graduate/common";
-import { forwardRef, PropsWithChildren, useEffect, useState } from "react";
 import {
+  forwardRef,
+  PropsWithChildren,
+  useEffect,
+  useState,
+  useContext,
+} from "react";
+import {
+  COOP_TITLE,
   DELETE_COURSE_AREA_DND_ID,
+  FALL_1,
   SEARCH_NEU_FETCH_COURSE_ERROR_MSG,
   isCourseFromSidebar,
 } from "../../utils";
@@ -20,9 +29,11 @@ import { COOP_BLOCK } from "../Sidebar";
 import { CourseDragIcon } from "./CourseDragIcon";
 import { CourseTrashButton } from "./CourseTrashButton";
 import { GraduateToolTip } from "../GraduateTooltip";
+import { TotalYearsContext } from "../Plan/Plan";
 
 interface DraggableScheduleCourseProps {
   scheduleCourse: ScheduleCourse2<string>;
+  scheduleTerm?: ScheduleTerm2<string>;
   coReqErr?: INEUReqError;
   preReqErr?: INEUReqError;
   isInSidebar?: boolean;
@@ -40,6 +51,7 @@ export const DraggableScheduleCourse: React.FC<
   DraggableScheduleCourseProps
 > = ({
   scheduleCourse,
+  scheduleTerm,
   removeCourse,
   preReqErr = undefined,
   coReqErr = undefined,
@@ -68,6 +80,7 @@ export const DraggableScheduleCourse: React.FC<
       preReqErr={preReqErr}
       ref={setNodeRef}
       scheduleCourse={scheduleCourse}
+      scheduleTerm={scheduleTerm}
       removeCourse={removeCourse}
       isInSidebar={isInSidebar}
       isChecked={isChecked}
@@ -186,6 +199,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
       coReqErr = undefined,
       preReqErr = undefined,
       scheduleCourse,
+      scheduleTerm,
       removeCourse,
       isInSidebar = false,
       isChecked = false,
@@ -202,7 +216,17 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
   ) => {
     const [hovered, setHovered] = useState(false);
     const isValidRemove = isRemove && !isFromSidebar;
-    const isCourseError = coReqErr !== undefined || preReqErr !== undefined;
+    const totalYears = useContext(TotalYearsContext);
+    const isFinalYear =
+      scheduleTerm && parseInt(scheduleTerm.id[0]) === totalYears;
+
+    const isCourseError =
+      coReqErr !== undefined ||
+      preReqErr !== undefined ||
+      (scheduleCourse.name === COOP_TITLE &&
+        scheduleTerm !== undefined &&
+        (scheduleTerm.id === FALL_1 ||
+          (isFinalYear && scheduleTerm.season === SeasonEnum.SP)));
 
     /*
     This component uses some plain HTML elements instead of Chakra
@@ -253,6 +277,7 @@ const ScheduleCourse = forwardRef<HTMLElement | null, ScheduleCourseProps>(
             <ReqErrorModal
               setHovered={setHovered}
               course={scheduleCourse}
+              term={scheduleTerm}
               coReqErr={coReqErr}
               preReqErr={preReqErr}
             />

--- a/packages/frontend/components/Sidebar/ConcentrationDropdownWarning.tsx
+++ b/packages/frontend/components/Sidebar/ConcentrationDropdownWarning.tsx
@@ -14,15 +14,15 @@ const ConcentrationDropdownWarning = () => {
     <Accordion pb="sm" allowToggle>
       <AccordionItem
         borderRadius="lg"
-        backgroundColor="red"
-        border="1px #5F6CF6 solid"
+        backgroundColor="red.100"
+        border="1px #e63433 solid"
       >
         <AccordionButton>
-          <InfoIcon mr="xs" color="blue" />
+          <InfoIcon mr="xs" color="red.400" />
           <Text fontWeight="semibold" textAlign="left" fontSize="md" flex="1">
             Missing Concentration!
           </Text>
-          <AccordionIcon color="black" />
+          <AccordionIcon color="red.400" />
         </AccordionButton>
         <AccordionPanel>
           <Text fontSize="sm">

--- a/packages/frontend/components/Sidebar/ConcentrationDropdownWarning.tsx
+++ b/packages/frontend/components/Sidebar/ConcentrationDropdownWarning.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { InfoIcon } from "@chakra-ui/icons";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+  Text,
+} from "@chakra-ui/react";
+
+const ConcentrationDropdownWarning = () => {
+  return (
+    <Accordion pb="sm" allowToggle>
+      <AccordionItem
+        borderRadius="lg"
+        backgroundColor="red"
+        border="1px #5F6CF6 solid"
+      >
+        <AccordionButton>
+          <InfoIcon mr="xs" color="blue" />
+          <Text fontWeight="semibold" textAlign="left" fontSize="md" flex="1">
+            Missing Concentration!
+          </Text>
+          <AccordionIcon color="black" />
+        </AccordionButton>
+        <AccordionPanel>
+          <Text fontSize="sm">
+            A concentration is required for this major. Go to &apos;Edit
+            plan&apos; and select your desired concentration from the drop-down
+            menu.
+          </Text>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export default ConcentrationDropdownWarning;

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -11,6 +11,8 @@ import {
   getAllCoursesFromPlan,
   getSectionError,
   getAllCoursesInMajor,
+  UNDECIDED_CONCENTRATION,
+  UNDECIDED,
 } from "../../utils";
 import {
   handleApiClientError,
@@ -210,8 +212,8 @@ const Sidebar: React.FC<SidebarProps> = memo(
       <SidebarContainer
         title={major.name}
         subtitle={
-          selectedPlan.concentration === "Undecided"
-            ? "Concentration Undecided"
+          selectedPlan.concentration === UNDECIDED
+            ? UNDECIDED_CONCENTRATION
             : selectedPlan.concentration
         }
         creditsTaken={creditsTaken}

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,7 @@ import {
   getSectionError,
   getAllCoursesInMajor,
   UNDECIDED_CONCENTRATION,
-  UNDECIDED,
+  UNDECIDED_STRING,
 } from "../../utils";
 import {
   handleApiClientError,
@@ -212,7 +212,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
       <SidebarContainer
         title={major.name}
         subtitle={
-          selectedPlan.concentration === UNDECIDED
+          selectedPlan.concentration === UNDECIDED_STRING
             ? UNDECIDED_CONCENTRATION
             : selectedPlan.concentration
         }

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -209,7 +209,11 @@ const Sidebar: React.FC<SidebarProps> = memo(
     return (
       <SidebarContainer
         title={major.name}
-        subtitle={selectedPlan.concentration}
+        subtitle={
+          selectedPlan.concentration === "Undecided"
+            ? "Concentration Undecided"
+            : selectedPlan.concentration
+        }
         creditsTaken={creditsTaken}
         creditsToTake={major.totalCreditsRequired}
         renderCoopBlock

--- a/packages/frontend/components/Sidebar/SidebarContainer.tsx
+++ b/packages/frontend/components/Sidebar/SidebarContainer.tsx
@@ -77,7 +77,9 @@ const SidebarContainer: React.FC<PropsWithChildren<SidebarContainerProps>> = ({
             </Text>
           )}
         </Box>
-        <ConcentrationDropdownWarning />
+        {subtitle === "Concentration Undecided" && (
+          <ConcentrationDropdownWarning />
+        )}
         {renderDropdownWarning && <DropdownWarning />}
         {creditsTaken !== undefined && (
           <Flex mb="sm" alignItems="baseline" columnGap="xs">

--- a/packages/frontend/components/Sidebar/SidebarContainer.tsx
+++ b/packages/frontend/components/Sidebar/SidebarContainer.tsx
@@ -7,7 +7,7 @@ import DropdownWarning from "./DropdownWarning";
 import ConcentrationDropdownWarning from "./ConcentrationDropdownWarning";
 import { COOP_BLOCK } from "./Sidebar";
 import { SandboxArea } from "./SandboxArea";
-import { UNDECIDED_CONCENTRATION } from "../../utils";
+import { UNDECIDED_CONCENTRATION } from "@graduate/common";
 
 interface SidebarContainerProps {
   title: string;

--- a/packages/frontend/components/Sidebar/SidebarContainer.tsx
+++ b/packages/frontend/components/Sidebar/SidebarContainer.tsx
@@ -7,6 +7,7 @@ import DropdownWarning from "./DropdownWarning";
 import ConcentrationDropdownWarning from "./ConcentrationDropdownWarning";
 import { COOP_BLOCK } from "./Sidebar";
 import { SandboxArea } from "./SandboxArea";
+import { UNDECIDED_CONCENTRATION } from "../../utils";
 
 interface SidebarContainerProps {
   title: string;
@@ -65,12 +66,12 @@ const SidebarContainer: React.FC<PropsWithChildren<SidebarContainerProps>> = ({
             <Text
               fontSize="sm"
               color={
-                subtitle === "Concentration Undecided"
+                subtitle === UNDECIDED_CONCENTRATION
                   ? "red.500"
                   : "primary.blue.dark.main"
               }
               fontStyle={
-                subtitle === "Concentration Undecided" ? "italic" : "normal"
+                subtitle === UNDECIDED_CONCENTRATION ? "italic" : "normal"
               }
             >
               {subtitle}

--- a/packages/frontend/components/Sidebar/SidebarContainer.tsx
+++ b/packages/frontend/components/Sidebar/SidebarContainer.tsx
@@ -4,6 +4,7 @@ import { BETA_MAJOR_TOOLTIP_MSG } from "../../utils";
 import { HelperToolTip } from "../Help";
 import { DraggableScheduleCourse } from "../ScheduleCourse";
 import DropdownWarning from "./DropdownWarning";
+import ConcentrationDropdownWarning from "./ConcentrationDropdownWarning";
 import { COOP_BLOCK } from "./Sidebar";
 import { SandboxArea } from "./SandboxArea";
 
@@ -61,11 +62,22 @@ const SidebarContainer: React.FC<PropsWithChildren<SidebarContainerProps>> = ({
             </Heading>
           </Flex>
           {subtitle && (
-            <Text fontSize="sm" color="primary.blue.dark.main">
+            <Text
+              fontSize="sm"
+              color={
+                subtitle === "Concentration Undecided"
+                  ? "red.500"
+                  : "primary.blue.dark.main"
+              }
+              fontStyle={
+                subtitle === "Concentration Undecided" ? "italic" : "normal"
+              }
+            >
               {subtitle}
             </Text>
           )}
         </Box>
+        <ConcentrationDropdownWarning />
         {renderDropdownWarning && <DropdownWarning />}
         {creditsTaken !== undefined && (
           <Flex mb="sm" alignItems="baseline" columnGap="xs">

--- a/packages/frontend/utils/constants.ts
+++ b/packages/frontend/utils/constants.ts
@@ -10,6 +10,13 @@ export const BETA_MAJOR_TOOLTIP_MSG =
   "Requirements for beta majors have not been validated and therefore may be inconsistent with your degree audit.";
 export const GEN_PLACEHOLDER_MSG =
   "General Placeholderse are generic courses that you can place in your plan if you do not know yet what to take but want the requirements to be fulfilled";
+export const FALL_1 = "1-FL";
+export const COOP_TITLE = "Co-op Education";
+export const FALL_1_COOP_ERROR_MSG =
+  "You may only register a co-op in your second year and beyond.";
+export const SPRING_4_COOP_ERROR_MSG =
+  "You cannot register a co-op in your last semester.";
+export const GENERIC_ERROR_MSG = "This is an error.";
 
 export const defaultGuestStudent: GetStudentResponse = {
   uuid: undefined,

--- a/packages/frontend/utils/constants.ts
+++ b/packages/frontend/utils/constants.ts
@@ -18,6 +18,7 @@ export const SPRING_4_COOP_ERROR_MSG =
   "You cannot register a co-op in your last semester.";
 export const GENERIC_ERROR_MSG = "This is an error.";
 export const UNDECIDED_CONCENTRATION = "Concentration Undecided";
+export const UNDECIDED = "Undecided";
 
 export const defaultGuestStudent: GetStudentResponse = {
   uuid: undefined,

--- a/packages/frontend/utils/constants.ts
+++ b/packages/frontend/utils/constants.ts
@@ -17,6 +17,7 @@ export const FALL_1_COOP_ERROR_MSG =
 export const SPRING_4_COOP_ERROR_MSG =
   "You cannot register a co-op in your last semester.";
 export const GENERIC_ERROR_MSG = "This is an error.";
+export const UNDECIDED_CONCENTRATION = "Concentration Undecided";
 
 export const defaultGuestStudent: GetStudentResponse = {
   uuid: undefined,

--- a/packages/frontend/utils/constants.ts
+++ b/packages/frontend/utils/constants.ts
@@ -18,7 +18,7 @@ export const SPRING_4_COOP_ERROR_MSG =
   "You cannot register a co-op in your last semester.";
 export const GENERIC_ERROR_MSG = "This is an error.";
 export const UNDECIDED_CONCENTRATION = "Concentration Undecided";
-export const UNDECIDED = "Undecided";
+export const UNDECIDED_STRING = "Undecided";
 
 export const defaultGuestStudent: GetStudentResponse = {
   uuid: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,7 +3120,7 @@ __metadata:
     "@types/passport": ^1.0.7
     "@types/passport-jwt": ^3.0.6
     "@types/supertest": ^2.0.11
-    bcrypt: 5.0.0
+    bcrypt: 5.1.1
     class-transformer: ^0.5.1
     class-validator: ^0.13.2
     cookie-parser: ^1.4.6
@@ -3553,6 +3553,25 @@ __metadata:
   version: 1.1.0
   resolution: "@lukeed/csprng@npm:1.1.0"
   checksum: 926f5f7fc629470ca9a8af355bfcd0271d34535f7be3890f69902432bddc3262029bb5dbe9025542cf6c9883d878692eef2815fc2f3ba5b92e9da1f9eba2e51b
+  languageName: node
+  linkType: hard
+
+"@mapbox/node-pre-gyp@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@mapbox/node-pre-gyp@npm:1.0.11"
+  dependencies:
+    detect-libc: ^2.0.0
+    https-proxy-agent: ^5.0.0
+    make-dir: ^3.1.0
+    node-fetch: ^2.6.7
+    nopt: ^5.0.0
+    npmlog: ^5.0.1
+    rimraf: ^3.0.2
+    semver: ^7.3.5
+    tar: ^6.1.11
+  bin:
+    node-pre-gyp: bin/node-pre-gyp
+  checksum: b848f6abc531a11961d780db813cc510ca5a5b6bf3184d72134089c6875a91c44d571ba6c1879470020803f7803609e7b2e6e429651c026fe202facd11d444b8
   languageName: node
   linkType: hard
 
@@ -5204,13 +5223,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "ansi-regex@npm:2.1.1"
-  checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
-  languageName: node
-  linkType: hard
-
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -5274,17 +5286,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3":
-  version: 1.2.0
-  resolution: "aproba@npm:1.2.0"
-  checksum: 0fca141966559d195072ed047658b6e6c4fe92428c385dd38e288eacfc55807e7b4989322f030faff32c0f46bb0bc10f1e0ac32ec22d25315a1e5bbc0ebb76dc
-  languageName: node
-  linkType: hard
-
 "aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
   checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "are-we-there-yet@npm:2.0.0"
+  dependencies:
+    delegates: ^1.0.0
+    readable-stream: ^3.6.0
+  checksum: 6c80b4fd04ecee6ba6e737e0b72a4b41bdc64b7d279edfc998678567ff583c8df27e27523bc789f2c99be603ffa9eaa612803da1d886962d2086e7ff6fa90c7c
   languageName: node
   linkType: hard
 
@@ -5295,16 +5310,6 @@ __metadata:
     delegates: ^1.0.0
     readable-stream: ^3.6.0
   checksum: 52590c24860fa7173bedeb69a4c05fb573473e860197f618b9a28432ee4379049336727ae3a1f9c4cb083114601c1140cee578376164d0e651217a9843f9fe83
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:~1.1.2":
-  version: 1.1.7
-  resolution: "are-we-there-yet@npm:1.1.7"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^2.0.6
-  checksum: 70d251719c969b2745bfe5ddf3ebaefa846a636e90a6d5212573676af5d6670e15457761d4725731e19cbebdce42c4ab0cbedf23ab047f2a08274985aa10a3c7
   languageName: node
   linkType: hard
 
@@ -5614,13 +5619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcrypt@npm:5.0.0":
-  version: 5.0.0
-  resolution: "bcrypt@npm:5.0.0"
+"bcrypt@npm:5.1.1":
+  version: 5.1.1
+  resolution: "bcrypt@npm:5.1.1"
   dependencies:
-    node-addon-api: ^3.0.0
-    node-pre-gyp: 0.15.0
-  checksum: 5e088c6f0d5c66c5ee29aef9ebae5bf4b38d87a25384a5118faa349d27ad2c04e5db6c384ad78ed5a9b90a9f027de8d2198f9f69775136cdf328c1d079ca196c
+    "@mapbox/node-pre-gyp": ^1.0.11
+    node-addon-api: ^5.0.0
+  checksum: 13523b1b1c8f7d7162001d197a600db038f995e0dfca67182f8c88d6de045a1f31b8e4d8a51d6a123ade57fc3828c0be828ea7ee57f7a08d24cd82c92bbaa441
   languageName: node
   linkType: hard
 
@@ -6005,13 +6010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chownr@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "chownr@npm:1.1.4"
-  checksum: 115648f8eb38bac5e41c3857f3e663f9c39ed6480d1349977c4d96c95a47266fcacc5a5aabf3cb6c481e22d72f41992827db47301851766c4fd77ac21a4f081d
-  languageName: node
-  linkType: hard
-
 "chownr@npm:^2.0.0":
   version: 2.0.0
   resolution: "chownr@npm:2.0.0"
@@ -6155,13 +6153,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"code-point-at@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "code-point-at@npm:1.1.0"
-  checksum: 17d5666611f9b16d64fdf48176d9b7fb1c7d1c1607a189f7e600040a11a6616982876af148230336adb7d8fe728a559f743a4e29db3747e3b1a32fa7f4529681
-  languageName: node
-  linkType: hard
-
 "collect-v8-coverage@npm:^1.0.0":
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
@@ -6201,7 +6192,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.3":
+"color-support@npm:^1.1.2, color-support@npm:^1.1.3":
   version: 1.1.3
   resolution: "color-support@npm:1.1.3"
   bin:
@@ -6300,7 +6291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0, console-control-strings@npm:~1.1.0":
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
   checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
@@ -6561,7 +6552,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^3.2.6, debug@npm:^3.2.7":
+"debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
   dependencies:
@@ -6590,13 +6581,6 @@ __metadata:
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
   checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
-  languageName: node
-  linkType: hard
-
-"deep-extend@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "deep-extend@npm:0.6.0"
-  checksum: 7be7e5a8d468d6b10e6a67c3de828f55001b6eb515d014f7aeb9066ce36bd5717161eb47d6a0f7bed8a9083935b465bc163ee2581c8b128d29bf61092fdf57a7
   languageName: node
   linkType: hard
 
@@ -6675,12 +6659,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "detect-libc@npm:1.0.3"
-  bin:
-    detect-libc: ./bin/detect-libc.js
-  checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+"detect-libc@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 2ba6a939ae55f189aea996ac67afceb650413c7a34726ee92c40fb0deb2400d57ef94631a8a3f052055eea7efb0f99a9b5e6ce923415daa3e68221f963cfc27d
   languageName: node
   linkType: hard
 
@@ -7879,15 +7861,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "fs-minipass@npm:1.2.7"
-  dependencies:
-    minipass: ^2.6.0
-  checksum: 40fd46a2b5dcb74b3a580269f9a0c36f9098c2ebd22cef2e1a004f375b7b665c11f1507ec3f66ee6efab5664109f72d0a74ea19c3370842214c3da5168d6fdd7
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -7977,6 +7950,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gauge@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "gauge@npm:3.0.2"
+  dependencies:
+    aproba: ^1.0.3 || ^2.0.0
+    color-support: ^1.1.2
+    console-control-strings: ^1.0.0
+    has-unicode: ^2.0.1
+    object-assign: ^4.1.1
+    signal-exit: ^3.0.0
+    string-width: ^4.2.3
+    strip-ansi: ^6.0.1
+    wide-align: ^1.1.2
+  checksum: 81296c00c7410cdd48f997800155fbead4f32e4f82109be0719c63edc8560e6579946cc8abd04205297640691ec26d21b578837fd13a4e96288ab4b40b1dc3e9
+  languageName: node
+  linkType: hard
+
 "gauge@npm:^4.0.3":
   version: 4.0.4
   resolution: "gauge@npm:4.0.4"
@@ -7990,22 +7980,6 @@ __metadata:
     strip-ansi: ^6.0.1
     wide-align: ^1.1.5
   checksum: 788b6bfe52f1dd8e263cda800c26ac0ca2ff6de0b6eee2fe0d9e3abf15e149b651bd27bf5226be10e6e3edb5c4e5d5985a5a1a98137e7a892f75eff76467ad2d
-  languageName: node
-  linkType: hard
-
-"gauge@npm:~2.7.3":
-  version: 2.7.4
-  resolution: "gauge@npm:2.7.4"
-  dependencies:
-    aproba: ^1.0.3
-    console-control-strings: ^1.0.0
-    has-unicode: ^2.0.0
-    object-assign: ^4.1.0
-    signal-exit: ^3.0.0
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wide-align: ^1.1.0
-  checksum: a89b53cee65579b46832e050b5f3a79a832cc422c190de79c6b8e2e15296ab92faddde6ddf2d376875cbba2b043efa99b9e1ed8124e7365f61b04e3cee9d40ee
   languageName: node
   linkType: hard
 
@@ -8267,7 +8241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.0, has-unicode@npm:^2.0.1":
+"has-unicode@npm:^2.0.1":
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
@@ -8449,7 +8423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24, iconv-lite@npm:^0.4.4":
+"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -8471,15 +8445,6 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
-  languageName: node
-  linkType: hard
-
-"ignore-walk@npm:^3.0.1":
-  version: 3.0.4
-  resolution: "ignore-walk@npm:3.0.4"
-  dependencies:
-    minimatch: ^3.0.4
-  checksum: 9e9c5ef6c3e0ed7ef5d797991abb554dbb7e60d5fedf6cf05c7129819689eba2b462f625c6e3561e0fc79841904eb829565513eeeab1b44f4fbec4d3146b1a8d
   languageName: node
   linkType: hard
 
@@ -8554,13 +8519,6 @@ __metadata:
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
-  languageName: node
-  linkType: hard
-
-"ini@npm:~1.3.0":
-  version: 1.3.8
-  resolution: "ini@npm:1.3.8"
-  checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
   languageName: node
   linkType: hard
 
@@ -8719,15 +8677,6 @@ __metadata:
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: df033653d06d0eb567461e58a7a8c9f940bd8c22274b94bf7671ab36df5719791aae15eef6d83bbb5e23283967f2f984b8914559d4449efda578c775c4be6f85
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "is-fullwidth-code-point@npm:1.0.0"
-  dependencies:
-    number-is-nan: ^1.0.0
-  checksum: 4d46a7465a66a8aebcc5340d3b63a56602133874af576a9ca42c6f0f4bd787a743605771c5f246db77da96605fefeffb65fc1dbe862dcc7328f4b4d03edf5a57
   languageName: node
   linkType: hard
 
@@ -9889,7 +9838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0":
+"make-dir@npm:^3.0.0, make-dir@npm:^3.1.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
@@ -10391,31 +10340,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^2.6.0, minipass@npm:^2.9.0":
-  version: 2.9.0
-  resolution: "minipass@npm:2.9.0"
-  dependencies:
-    safe-buffer: ^5.1.2
-    yallist: ^3.0.0
-  checksum: 077b66f31ba44fd5a0d27d12a9e6a86bff8f97a4978dedb0373167156b5599fadb6920fdde0d9f803374164d810e05e8462ce28e86abbf7f0bea293a93711fc6
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^3.0.0, minipass@npm:^3.1.1, minipass@npm:^3.1.6":
   version: 3.3.5
   resolution: "minipass@npm:3.3.5"
   dependencies:
     yallist: ^4.0.0
   checksum: f89f02bcaa0e0e4bb4c44ec796008e69fbca62db0aba6ead1bc57d25bdaefdf42102130f4f9ecb7d9c6b6cd35ff7b0c7b97d001d3435da8e629fb68af3aea57e
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "minizlib@npm:1.3.3"
-  dependencies:
-    minipass: ^2.9.0
-  checksum: b0425c04d2ae6aad5027462665f07cc0d52075f7fa16e942b4611115f9b31f02924073b7221be6f75929d3c47ab93750c63f6dc2bbe8619ceacb3de1f77732c0
   languageName: node
   linkType: hard
 
@@ -10429,7 +10359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^0.5.3, mkdirp@npm:^0.5.4, mkdirp@npm:^0.5.5":
+"mkdirp@npm:^0.5.4":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -10539,19 +10469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"needle@npm:^2.5.0":
-  version: 2.9.1
-  resolution: "needle@npm:2.9.1"
-  dependencies:
-    debug: ^3.2.6
-    iconv-lite: ^0.4.4
-    sax: ^1.2.4
-  bin:
-    needle: ./bin/needle
-  checksum: 746ae3a3782f0a057ff304a98843cc6f2009f978a0fad0c3e641a9d46d0b5702bb3e197ba08aecd48678067874a991c4f5fc320c7e51a4c041d9dd3441146cf0
-  languageName: node
-  linkType: hard
-
 "negotiator@npm:0.6.3, negotiator@npm:^0.6.3":
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
@@ -10635,12 +10552,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.0.0":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
   dependencies:
     node-gyp: latest
-  checksum: 2369986bb0881ccd9ef6bacdf39550e07e089a9c8ede1cbc5fc7712d8e2faa4d50da0e487e333d4125f8c7a616c730131d1091676c9d499af1d74560756b4a18
+  checksum: 2508bd2d2981945406243a7bd31362fc7af8b70b8b4d65f869c61731800058fb818cc2fd36c8eac714ddd0e568cc85becf5e165cebbdf7b5024d5151bbc75ea1
   languageName: node
   linkType: hard
 
@@ -10664,6 +10581,20 @@ __metadata:
     encoding:
       optional: true
   checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.7":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
   languageName: node
   linkType: hard
 
@@ -10694,26 +10625,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-pre-gyp@npm:0.15.0":
-  version: 0.15.0
-  resolution: "node-pre-gyp@npm:0.15.0"
-  dependencies:
-    detect-libc: ^1.0.2
-    mkdirp: ^0.5.3
-    needle: ^2.5.0
-    nopt: ^4.0.1
-    npm-packlist: ^1.1.6
-    npmlog: ^4.0.2
-    rc: ^1.2.7
-    rimraf: ^2.6.1
-    semver: ^5.3.0
-    tar: ^4.4.2
-  bin:
-    node-pre-gyp: ./bin/node-pre-gyp
-  checksum: dc385eb2dbce7302ca587e84410c59086908af0a3a78613563f36bdf9d9aa15dc493b63618d7b8cceb6a984c55ece51619edd11cd0ec98c552ba4a7ea881703e
-  languageName: node
-  linkType: hard
-
 "node-releases@npm:^2.0.6":
   version: 2.0.6
   resolution: "node-releases@npm:2.0.6"
@@ -10725,18 +10636,6 @@ __metadata:
   version: 6.9.1
   resolution: "nodemailer@npm:6.9.1"
   checksum: b1b9670afc170b4454665abae3fc9acd7e781adb9f579d1c2cd991bf75c647ebe345593f8a057e48d7bf9e4c9a9218869f87db8fb7171c614f557000ab654572
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^4.0.1":
-  version: 4.0.3
-  resolution: "nopt@npm:4.0.3"
-  dependencies:
-    abbrev: 1
-    osenv: ^0.1.4
-  bin:
-    nopt: bin/nopt.js
-  checksum: 66cd3b6021fc8130fc201236bc3dce614fc86988b78faa91377538b09d57aad9ba4300b5d6a01dc93d6c6f2c170f81cc893063d496d108150b65191beb4a50a4
   languageName: node
   linkType: hard
 
@@ -10770,33 +10669,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-bundled@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "npm-bundled@npm:1.1.2"
-  dependencies:
-    npm-normalize-package-bin: ^1.0.1
-  checksum: 6e599155ef28d0b498622f47f1ba189dfbae05095a1ed17cb3a5babf961e965dd5eab621f0ec6f0a98de774e5836b8f5a5ee639010d64f42850a74acec3d4d09
-  languageName: node
-  linkType: hard
-
-"npm-normalize-package-bin@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "npm-normalize-package-bin@npm:1.0.1"
-  checksum: ae7f15155a1e3ace2653f12ddd1ee8eaa3c84452fdfbf2f1943e1de264e4b079c86645e2c55931a51a0a498cba31f70022a5219d5665fbcb221e99e58bc70122
-  languageName: node
-  linkType: hard
-
-"npm-packlist@npm:^1.1.6":
-  version: 1.4.8
-  resolution: "npm-packlist@npm:1.4.8"
-  dependencies:
-    ignore-walk: ^3.0.1
-    npm-bundled: ^1.0.1
-    npm-normalize-package-bin: ^1.0.1
-  checksum: 85f764bd0fb516cff34afb4b60ea925ef218cfbdf02d05cda0c115ca30b932b9e0f78bdb186e09d26dd17f983ee1d5aee7ba44b5db84ff3c4c5e73524b537084
-  languageName: node
-  linkType: hard
-
 "npm-run-path@npm:^4.0.0, npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -10806,15 +10678,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npmlog@npm:^4.0.2":
-  version: 4.1.2
-  resolution: "npmlog@npm:4.1.2"
+"npmlog@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "npmlog@npm:5.0.1"
   dependencies:
-    are-we-there-yet: ~1.1.2
-    console-control-strings: ~1.1.0
-    gauge: ~2.7.3
-    set-blocking: ~2.0.0
-  checksum: edbda9f95ec20957a892de1839afc6fb735054c3accf6fbefe767bac9a639fd5cea2baeac6bd2bcd50a85cb54924d57d9886c81c7fbc2332c2ddd19227504192
+    are-we-there-yet: ^2.0.0
+    console-control-strings: ^1.1.0
+    gauge: ^3.0.0
+    set-blocking: ^2.0.0
+  checksum: 516b2663028761f062d13e8beb3f00069c5664925871a9b57989642ebe09f23ab02145bf3ab88da7866c4e112cafff72401f61a672c7c8a20edc585a7016ef5f
   languageName: node
   linkType: hard
 
@@ -10830,13 +10702,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"number-is-nan@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "number-is-nan@npm:1.0.1"
-  checksum: 13656bc9aa771b96cef209ffca31c31a03b507ca6862ba7c3f638a283560620d723d52e626d57892c7fff475f4c36ac07f0600f14544692ff595abff214b9ffb
-  languageName: node
-  linkType: hard
-
 "nwsapi@npm:^2.2.0":
   version: 2.2.2
   resolution: "nwsapi@npm:2.2.2"
@@ -10844,7 +10709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.0, object-assign@npm:^4.1.1":
+"object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
@@ -10992,13 +10857,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-homedir@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "os-homedir@npm:1.0.2"
-  checksum: af609f5a7ab72de2f6ca9be6d6b91a599777afc122ac5cad47e126c1f67c176fe9b52516b9eeca1ff6ca0ab8587fe66208bc85e40a3940125f03cdb91408e9d2
-  languageName: node
-  linkType: hard
-
 "os-name@npm:4.0.1":
   version: 4.0.1
   resolution: "os-name@npm:4.0.1"
@@ -11009,20 +10867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:^1.0.0, os-tmpdir@npm:~1.0.2":
+"os-tmpdir@npm:~1.0.2":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
-  languageName: node
-  linkType: hard
-
-"osenv@npm:^0.1.4":
-  version: 0.1.5
-  resolution: "osenv@npm:0.1.5"
-  dependencies:
-    os-homedir: ^1.0.0
-    os-tmpdir: ^1.0.0
-  checksum: 779d261920f2a13e5e18cf02446484f12747d3f2ff82280912f52b213162d43d312647a40c332373cbccd5e3fb8126915d3bfea8dde4827f70f82da76e52d359
   languageName: node
   linkType: hard
 
@@ -11619,20 +11467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rc@npm:^1.2.7":
-  version: 1.2.8
-  resolution: "rc@npm:1.2.8"
-  dependencies:
-    deep-extend: ^0.6.0
-    ini: ~1.3.0
-    minimist: ^1.2.0
-    strip-json-comments: ~2.0.1
-  bin:
-    rc: ./cli.js
-  checksum: 2e26e052f8be2abd64e6d1dabfbd7be03f80ec18ccbc49562d31f617d0015fbdbcf0f9eed30346ea6ab789e0fdfe4337f033f8016efdbee0df5354751842080e
-  languageName: node
-  linkType: hard
-
 "react-clientside-effect@npm:^1.2.6":
   version: 1.2.6
   resolution: "react-clientside-effect@npm:1.2.6"
@@ -11870,7 +11704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.0.6, readable-stream@npm:^2.2.2":
+"readable-stream@npm:^2.2.2":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
   dependencies:
@@ -12162,17 +11996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:^2.6.1":
-  version: 2.7.1
-  resolution: "rimraf@npm:2.7.1"
-  dependencies:
-    glob: ^7.1.3
-  bin:
-    rimraf: ./bin.js
-  checksum: cdc7f6eacb17927f2a075117a823e1c5951792c6498ebcce81ca8203454a811d4cf8900314154d3259bb8f0b42ab17f67396a8694a54cae3283326e57ad250cd
-  languageName: node
-  linkType: hard
-
 "run-async@npm:^2.4.0":
   version: 2.4.1
   resolution: "run-async@npm:2.4.1"
@@ -12216,7 +12039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -12248,7 +12071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:>=0.6.0, sax@npm:^1.2.4":
+"sax@npm:>=0.6.0":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
   checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
@@ -12284,7 +12107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.6.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
   bin:
@@ -12355,7 +12178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0, set-blocking@npm:~2.0.0":
+"set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
@@ -12633,17 +12456,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "string-width@npm:1.0.2"
-  dependencies:
-    code-point-at: ^1.0.0
-    is-fullwidth-code-point: ^1.0.0
-    strip-ansi: ^3.0.0
-  checksum: 5c79439e95bc3bd7233a332c5f5926ab2ee90b23816ed4faa380ce3b2576d7800b0a5bb15ae88ed28737acc7ea06a518c2eef39142dd727adad0e45c776cd37e
-  languageName: node
-  linkType: hard
-
 "string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.0.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.2, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -12711,15 +12523,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^3.0.0, strip-ansi@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "strip-ansi@npm:3.0.1"
-  dependencies:
-    ansi-regex: ^2.0.0
-  checksum: 9b974de611ce5075c70629c00fa98c46144043db92ae17748fb780f706f7a789e9989fd10597b7c2053ae8d1513fd707816a91f1879b2f71e6ac0b6a863db465
-  languageName: node
-  linkType: hard
-
 "strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
@@ -12754,13 +12557,6 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
-  languageName: node
-  linkType: hard
-
-"strip-json-comments@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "strip-json-comments@npm:2.0.1"
-  checksum: 1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
   languageName: node
   linkType: hard
 
@@ -12902,21 +12698,6 @@ __metadata:
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 3b7a1b4d86fa940aad46d9e73d1e8739335efd4c48322cb37d073eb6f80f5281889bf0320c6d8ffcfa1a0dd5bfdbd0f9d037e252ef972aca595330538aac4d51
-  languageName: node
-  linkType: hard
-
-"tar@npm:^4.4.2":
-  version: 4.4.19
-  resolution: "tar@npm:4.4.19"
-  dependencies:
-    chownr: ^1.1.4
-    fs-minipass: ^1.2.7
-    minipass: ^2.9.0
-    minizlib: ^1.3.3
-    mkdirp: ^0.5.5
-    safe-buffer: ^5.2.1
-    yallist: ^3.1.1
-  checksum: 423c8259b17f8f612cef9c96805d65f90ba9a28e19be582cd9d0fcb217038219f29b7547198e8fd617da5f436376d6a74b99827acd1238d2f49cf62330f9664e
   languageName: node
   linkType: hard
 
@@ -13957,7 +13738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.0, wide-align@npm:^1.1.5":
+"wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
   dependencies:
@@ -14078,13 +13859,6 @@ __metadata:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^3.0.0, yallist@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "yallist@npm:3.1.1"
-  checksum: 48f7bb00dc19fc635a13a39fe547f527b10c9290e7b3e836b9a8f1ca04d4d342e85714416b3c2ab74949c9c66f9cebb0473e6bc353b79035356103b47641285d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

For all majors that have concentrations, you can now select undecided as an option.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Frontend changes to add undecided as an option when selecting concentrations as well as displaying warning dropdowns letting you know that the concentration is undecided and will eventually need changing. Also some backend validation changes that allow an undecided concentration to exist even though it's not defined anywhere in the major. 

Closes #790 

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?

Visually

![Screenshot 2025-01-31 at 6 26 34 PM](https://github.com/user-attachments/assets/a63195ef-5301-41dc-b59e-743a6eeaec52)

![Screenshot 2025-01-31 at 6 26 59 PM](https://github.com/user-attachments/assets/d1b10091-f019-4a65-b9ac-155473e5f420)

