### PR TITLE
edited ssl path

### DIFF
--- a/packages/api/ormconfig.ts
+++ b/packages/api/ormconfig.ts
@@ -30,7 +30,7 @@ if (
   ormconfig.extra = {
     ssl: {
       ca: readFileSync(
-        join(__dirname, "assets", "RDS.us-east-1.ca-bundle.pem")
+        join("assets", "RDS.us-east-1.ca-bundle.pem")
       ).toString(),
     },
   };


### PR DESCRIPTION
# Description
Changing path in ormconfig.ts to *hopefully* fix the SSL issues we've been getting. This file is already in /api so should be able to just access the cert through /assets/path_to_cert

