### PR TITLE
no more logging entire json files

### DIFF
--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,11 +1,6 @@
-import {
-  ClassSerializerInterceptor,
-  LogLevel,
-  LoggerService,
-  ValidationPipe,
-} from "@nestjs/common";
+import { LogLevel, LoggerService, ValidationPipe } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { NestFactory, Reflector } from "@nestjs/core";
+import { NestFactory } from "@nestjs/core";
 import { GraduateLogger } from "./graduate-logger";
 import { AppModule } from "./app.module";
 import { EnvironmentVariables } from "./environment-variables";
@@ -47,7 +42,7 @@ async function bootstrap() {
    * work, returned objects in controllers have to be an actual instance of the
    * type with the appropriate decorators.
    */
-  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  //app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   /** All paths are prefixed with /api. */
   app.setGlobalPrefix("api");

--- a/packages/api/src/major/major-collator.ts
+++ b/packages/api/src/major/major-collator.ts
@@ -164,9 +164,9 @@ async function collateMajors() {
             // Also store the template under the major name for consistent lookup
             TEMPLATES[year][majorName] = template;
           } else {
-            console.log(
-              `Stored template for ${templateKey} (${year}) but couldn't associate with a major`
-            );
+            //console.log(
+            //`Stored template for ${templateKey} (${year}) but couldn't associate with a major`
+            //);
           }
         }
       } catch (error) {


### PR DESCRIPTION
# Description
Removed interceptor for main api. This makes it so that it doesn't log every single major json file when we make the api call! Might be worth looking into again so we log actually important information.