### PR TITLE
Logging cleanup

### DIFF
--- a/packages/api/src/interceptors/logging.interceptor.ts
+++ b/packages/api/src/interceptors/logging.interceptor.ts
@@ -75,7 +75,11 @@ export class LoggingInterceptor implements NestInterceptor {
     const { statusCode } = res;
     const ctx = this.formatCtx(LogType.Response, method, url, statusCode);
 
-    this.logger.log({ body }, ctx);
+    if (url.includes("/major") || url.includes("/minor")) {
+      this.logger.log({ body: { hidden: true } }, ctx);
+    } else {
+      this.logger.log({ body }, ctx);
+    }
   }
 
   /**

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,6 +1,11 @@
-import { LogLevel, LoggerService, ValidationPipe } from "@nestjs/common";
+import {
+  ClassSerializerInterceptor,
+  LogLevel,
+  LoggerService,
+  ValidationPipe,
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { NestFactory } from "@nestjs/core";
+import { NestFactory, Reflector } from "@nestjs/core";
 import { GraduateLogger } from "./graduate-logger";
 import { AppModule } from "./app.module";
 import { EnvironmentVariables } from "./environment-variables";
@@ -42,7 +47,7 @@ async function bootstrap() {
    * work, returned objects in controllers have to be an actual instance of the
    * type with the appropriate decorators.
    */
-  //app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   /** All paths are prefixed with /api. */
   app.setGlobalPrefix("api");


### PR DESCRIPTION
# Description

hides the body of responses that have to do with /major and /minor because they take up the entire terminal space and dont help