### PR TITLE
Flexible minors

### DIFF
--- a/packages/api-client/index.ts
+++ b/packages/api-client/index.ts
@@ -94,7 +94,7 @@ class APIClient {
       this.req("GET", "/students/me", GetStudentResponse, undefined, {
         isWithPlans: true,
       }),
-    delete: (): Promise<void> => this.req("DELETE", "students/me"),
+    delete: (): Promise<void> => this.req("DELETE", "/students/me"),
     changePassword: (body: ChangePasswordDto): Promise<void> =>
       this.req("POST", "/students/changePassword", undefined, body),
   };

--- a/packages/api/migrations/1757878658490-ReplaceMinorWithMinorsArray.ts
+++ b/packages/api/migrations/1757878658490-ReplaceMinorWithMinorsArray.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReplaceMinorWithMinorsArray1757878658490
+  implements MigrationInterface
+{
+  name = "ReplaceMinorWithMinorsArray1757878658490";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "student" RENAME COLUMN "minor" TO "minors"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "plan" RENAME COLUMN "minor" TO "minors"`
+    );
+    await queryRunner.query(`ALTER TABLE "student" DROP COLUMN "minors"`);
+    await queryRunner.query(`ALTER TABLE "student" ADD "minors" text array`);
+    await queryRunner.query(`ALTER TABLE "plan" DROP COLUMN "minors"`);
+    await queryRunner.query(`ALTER TABLE "plan" ADD "minors" text array`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plan" DROP COLUMN "minors"`);
+    await queryRunner.query(
+      `ALTER TABLE "plan" ADD "minors" character varying`
+    );
+    await queryRunner.query(`ALTER TABLE "student" DROP COLUMN "minors"`);
+    await queryRunner.query(
+      `ALTER TABLE "student" ADD "minors" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "plan" RENAME COLUMN "minors" TO "minor"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "student" RENAME COLUMN "minors" TO "minor"`
+    );
+  }
+}

--- a/packages/api/src/plan/entities/plan.entity.ts
+++ b/packages/api/src/plan/entities/plan.entity.ts
@@ -28,8 +28,8 @@ export class Plan {
   @Column("text", { array: true, nullable: true })
   majors: string[];
 
-  @Column({ nullable: true })
-  minor: string;
+  @Column("text", { array: true, nullable: true })
+  minors: string[];
 
   @Column({ nullable: true })
   concentration: string;

--- a/packages/api/src/plan/plan.service.ts
+++ b/packages/api/src/plan/plan.service.ts
@@ -124,7 +124,7 @@ export class PlanService {
   ): Promise<UpdateResult> {
     const {
       majors: newMajors,
-      minor: newMinorName,
+      minors: newMinorNames,
       catalogYear: newCatalogYear,
       concentration: newConcentrationName,
       schedule: newSchedule,
@@ -161,7 +161,7 @@ export class PlanService {
 
     /** Wipe Minor => Remove existing minor from the plan. */
     const isWipeMinorUpdate =
-      !newMinorName && !newCatalogYear && currentPlan.minors;
+      !newMinorNames && !newCatalogYear && currentPlan.minors;
 
     const isScheduleUpdate = newSchedule && !isMajorInfoUpdate;
 
@@ -248,7 +248,7 @@ export class PlanService {
     let name = currentPlan.name;
     let schedule = currentPlan.schedule;
     let majors = isWipeMajorUpdate ? undefined : currentPlan.majors;
-    let minor = isWipeMinorUpdate ? undefined : currentPlan.minors;
+    let minors = isWipeMinorUpdate ? undefined : currentPlan.minors;
     let catalogYear = isWipeMajorUpdate ? undefined : currentPlan.catalogYear;
     let concentration = isWipeMajorUpdate
       ? undefined
@@ -268,14 +268,14 @@ export class PlanService {
       concentration = newConcentrationName;
     }
 
-    if (newMinorName) {
-      minor = [newMinorName];
+    if (newMinorNames) {
+      minors = newMinorNames;
     }
 
     const newPlan = {
       name,
       majors,
-      minor,
+      minors,
       catalogYear,
       concentration,
       schedule,

--- a/packages/api/src/plan/plan.service.ts
+++ b/packages/api/src/plan/plan.service.ts
@@ -161,7 +161,7 @@ export class PlanService {
 
     /** Wipe Minor => Remove existing minor from the plan. */
     const isWipeMinorUpdate =
-      !newMinorName && !newCatalogYear && currentPlan.minor;
+      !newMinorName && !newCatalogYear && currentPlan.minors;
 
     const isScheduleUpdate = newSchedule && !isMajorInfoUpdate;
 
@@ -248,7 +248,7 @@ export class PlanService {
     let name = currentPlan.name;
     let schedule = currentPlan.schedule;
     let majors = isWipeMajorUpdate ? undefined : currentPlan.majors;
-    let minor = isWipeMinorUpdate ? undefined : currentPlan.minor;
+    let minor = isWipeMinorUpdate ? undefined : currentPlan.minors;
     let catalogYear = isWipeMajorUpdate ? undefined : currentPlan.catalogYear;
     let concentration = isWipeMajorUpdate
       ? undefined
@@ -269,7 +269,7 @@ export class PlanService {
     }
 
     if (newMinorName) {
-      minor = newMinorName;
+      minor = [newMinorName];
     }
 
     const newPlan = {

--- a/packages/api/src/student/entities/student.entity.ts
+++ b/packages/api/src/student/entities/student.entity.ts
@@ -49,8 +49,8 @@ export class Student {
   @Column("text", { array: true, nullable: true })
   majors: string[];
 
-  @Column({ nullable: true })
-  minor: string;
+  @Column("text", { array: true, nullable: true })
+  minors: string[];
 
   @Column({ nullable: true })
   coopCycle: string;

--- a/packages/common/src/api-dtos.ts
+++ b/packages/common/src/api-dtos.ts
@@ -26,9 +26,10 @@ export class CreatePlanDtoWithoutSchedule {
   @IsOptional()
   majors?: string[];
 
-  @IsString()
   @IsOptional()
-  minor?: string;
+  @IsArray()
+  @IsString({ each: true })
+  minors?: string[];
 
   @IsString()
   @IsOptional()
@@ -65,8 +66,9 @@ export class UpdatePlanDto {
   majors?: string[];
 
   @IsOptional()
-  @IsString()
-  minor?: string;
+  @IsArray()
+  @IsString({ each: true })
+  minors?: string[];
 
   @IsOptional()
   @IsString()
@@ -134,8 +136,9 @@ export class UpdateStudentDto {
   majors?: string[];
 
   @IsOptional()
-  @IsString()
-  minor?: string;
+  @IsArray()
+  @IsString({ each: true })
+  minors?: string[];
 
   @IsOptional()
   @IsString()
@@ -189,8 +192,9 @@ export class OnboardStudentDto {
   @IsString({ each: true })
   majors: string[];
 
-  @IsString()
-  minor: string;
+  @IsArray()
+  @IsString({ each: true })
+  minors: string[];
 
   @IsString()
   coopCycle: string;

--- a/packages/common/src/api-response-types.ts
+++ b/packages/common/src/api-response-types.ts
@@ -20,7 +20,7 @@ export class PlanModel<T> {
   catalogYear: number;
   createdAt: Date;
   updatedAt: Date;
-  minor?: string;
+  minors?: string[];
 }
 
 export class GetPlanResponse extends PlanModel<null> {}
@@ -38,7 +38,7 @@ export class StudentModel<T> {
   graduateYear: number | undefined;
   catalogYear: number | undefined;
   majors: string[] | undefined;
-  minor?: string | undefined;
+  minors?: string[] | undefined;
   coopCycle: string | undefined;
   coursesCompleted: ScheduleCourse[] | undefined;
   coursesTransfered: ScheduleCourse2<null>[] | undefined;

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -164,7 +164,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
       name: payload.name || generateDefaultPlanTitle(),
       catalogYear: isNoMajorSelected ? undefined : payload.catalogYear,
       majors: isNoMajorSelected ? undefined : payload.majors,
-      minor: isNoMinorSelected ? undefined : payload.minor,
+      minors: isNoMinorSelected ? undefined : payload.minors,
       concentration: isNoMajorSelected ? undefined : payload.concentration,
       schedule,
     };

--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -424,7 +424,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                     <PlanSelect
                       label="Minor"
                       placeholder="Select a Minor"
-                      name="minor"
+                      name="minors"
                       control={control}
                       options={extractSupportedMinorOptions(
                         catalogYear,
@@ -433,6 +433,7 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
                       isDisabled={!catalogYear}
                       isSearchable
                       useFuzzySearch
+                      isMulti={true}
                     />
                     <Flex align="center">
                       <Text size="xs" mr="xs">

--- a/packages/frontend/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend/components/Plan/EditPlanModal.tsx
@@ -52,7 +52,7 @@ type EditPlanModalProps = {
 type EditPlanInput = {
   name: string;
   majors: string[];
-  minor?: string;
+  minors?: string[];
   catalogYear: number;
   concentration: string;
   agreeToBetaMajor: boolean;
@@ -92,7 +92,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
       name: plan.name,
       catalogYear: plan.catalogYear,
       majors: plan.majors,
-      minor: plan.minor,
+      minors: plan.minors,
       concentration: plan.concentration,
     });
 
@@ -121,6 +121,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
   const title = watch("name");
   const catalogYear = watch("catalogYear");
   const majors = watch("majors");
+  const minors = watch("minors");
   const concentration = watch("concentration");
   const agreeToBetaMajor = watch("agreeToBetaMajor");
 
@@ -130,7 +131,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
   const noConcentrations = { concentrations: [], minRequiredConcentrations: 0 };
 
   const majorConcentrations =
-    yearSupportedMajors?.[majors[0] ?? ""] ?? noConcentrations;
+    yearSupportedMajors?.[majors?.[0] ?? ""] ?? noConcentrations;
 
   const isConcentrationRequired =
     majorConcentrations.minRequiredConcentrations > 0;
@@ -138,7 +139,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
   const majorHasConcentrations = majorConcentrations.concentrations.length > 0;
 
   const isValidatedMajor =
-    yearSupportedMajors?.[majors[0] ?? ""]?.verified ?? false;
+    yearSupportedMajors?.[majors?.[0] ?? ""]?.verified ?? false;
 
   const isValidForm =
     (title &&
@@ -168,7 +169,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
       catalogYear: isNoMajorSelected ? undefined : payload.catalogYear,
       majors: isNoMajorSelected ? undefined : payload.majors,
       concentration: isNoMajorSelected ? undefined : payload.concentration,
-      minor: payload.minor,
+      minors: payload.minors,
     };
 
     if (isGuest) {
@@ -379,19 +380,56 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                         useFuzzySearch
                       />
                     )}
-                    <PlanSelect
-                      label="Minor"
-                      placeholder="Select a Minor"
-                      name="minor"
-                      control={control}
-                      options={extractSupportedMinorOptions(
-                        catalogYear,
-                        supportedMinorsData
-                      )}
-                      isDisabled={!catalogYear}
-                      isSearchable
-                      useFuzzySearch
-                    />
+                    {minors?.map((minor, index) => (
+                      <Box key={index} w="100%">
+                        <PlanSelect
+                          label={
+                            index === 0 ? "Minor(s)" : `Minor ${index + 1}`
+                          }
+                          placeholder="Select a Minor"
+                          name={`minors.${index}`}
+                          isMulti={false}
+                          control={control}
+                          options={extractSupportedMinorOptions(
+                            catalogYear,
+                            supportedMinorsData
+                          )}
+                          isDisabled={!catalogYear}
+                          isSearchable
+                          useFuzzySearch
+                          removeButton={
+                            index > 0 ? (
+                              <SmallCloseIcon
+                                position="absolute"
+                                top="8px"
+                                right="8px"
+                                cursor="pointer"
+                                color="red.500"
+                                boxSize="16px"
+                                _hover={{ color: "red.700" }}
+                                onClick={() => {
+                                  const newMinors = minors.filter(
+                                    (_, i) => i !== index
+                                  );
+                                  setValue("minors", newMinors);
+                                }}
+                              />
+                            ) : undefined
+                          }
+                        />
+                      </Box>
+                    ))}
+                    <Text
+                      cursor="pointer"
+                      textColor="blue.500"
+                      fontWeight="bold"
+                      onClick={() => {
+                        const currentMinors = minors || [];
+                        setValue("minors", [...currentMinors, ""]);
+                      }}
+                    >
+                      + Add a Minor
+                    </Text>
                     {majors && !isValidatedMajor && (
                       <Flex alignItems="center">
                         <Checkbox

--- a/packages/frontend/components/Sidebar/Sidebar.tsx
+++ b/packages/frontend/components/Sidebar/Sidebar.tsx
@@ -95,10 +95,10 @@ const Sidebar: React.FC<SidebarProps> = memo(
           );
 
     const {
-      minor,
+      minors,
       isLoading: isMinorLoading,
       error: minorError,
-    } = useMinor(selectedPlan.catalogYear, selectedPlan.minor ?? "");
+    } = useMinor(selectedPlan.catalogYear, selectedPlan.minors);
 
     const workerRef = useRef<Worker>();
 
@@ -118,7 +118,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
       currentRequestNum += 1;
       const validationInfo: WorkerPostInfo = {
         major: majors[0],
-        minor: minor,
+        minor: minors[0],
         taken: coursesTaken,
         concentration: selectedPlan.concentration,
         requestNumber: currentRequestNum,
@@ -175,7 +175,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
     useEffect(() => revalidateMajor(), [selectedPlan, majors[0]]);
 
     const majorCourses = getAllCoursesInMajor(majors[0], concentration);
-    const minorCourses = getAllCoursesInMinor(minor);
+    const minorCourses = getAllCoursesInMinor(minors[0]);
 
     const {
       courses,
@@ -207,7 +207,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
       return <SidebarContainer title="" />;
     }
 
-    if (selectedPlan.minor && !minor) {
+    if (selectedPlan.minors && !minors[0]) {
       if (minorError) {
         handleApiClientError(minorError, router);
       }
@@ -236,7 +236,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
 
     const concentrationValidationError: MajorValidationError | undefined =
       getSectionError(
-        (majors[0] ? 1 : 0) + (minor ? 1 : 0), // offset by major and minor length
+        (majors[0] ? 1 : 0) + (minors[0] ? 1 : 0), // offset by major and minor length
         0, // the concentration AND index is always 0
         validationStatus
       );
@@ -313,7 +313,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
                 >
                   MAJOR
                 </Tab>
-                {minor && (
+                {minors[0] && (
                   <Tab
                     _selected={{ color: "white", bg: "blue.800" }}
                     flex="0.4"
@@ -364,7 +364,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
                   )}
                 </TabPanel>
                 <TabPanel width="100%" p={0} m={0}>
-                  {minor && (
+                  {minors[0] && (
                     <>
                       <Flex>
                         <Heading
@@ -376,7 +376,7 @@ const Sidebar: React.FC<SidebarProps> = memo(
                           Minor Requirements
                         </Heading>
                       </Flex>
-                      {minor.requirementSections.map((section, index) => {
+                      {minors[0].requirementSections.map((section, index) => {
                         const sectionValidationError:
                           | MajorValidationError
                           | undefined = getSectionError(

--- a/packages/frontend/hooks/useMajor.ts
+++ b/packages/frontend/hooks/useMajor.ts
@@ -13,13 +13,16 @@ export function useMajor(
   catalogYear: number,
   majorNames: string[]
 ): MajorReturn {
+  const safeMajorNames = (majorNames || []).filter(
+    (name) => name && name.trim() !== ""
+  );
   const key =
-    majorNames.length > 0
-      ? `api/majors/${catalogYear}/${majorNames.join(",")}`
+    safeMajorNames.length > 0
+      ? `api/majors/${catalogYear}/${safeMajorNames.join(",")}`
       : null;
 
   const { data, error } = useSWR(key, async () => {
-    const promises = majorNames.map((majorName) =>
+    const promises = safeMajorNames.map((majorName) =>
       API.majors.get(catalogYear, majorName)
     );
     return Promise.all(promises);
@@ -27,7 +30,7 @@ export function useMajor(
 
   return {
     majors: data || [],
-    isLoading: !data && !error,
+    isLoading: key !== null && !data && !error,
     error,
   };
 }

--- a/packages/frontend/hooks/useMinor.ts
+++ b/packages/frontend/hooks/useMinor.ts
@@ -13,7 +13,9 @@ export function useMinor(
   catalogYear: number,
   minorNames?: string[]
 ): MinorReturn {
-  const safeMinorNames = minorNames || [];
+  const safeMinorNames = (minorNames || []).filter(
+    (name) => name && name.trim() !== ""
+  );
   const key =
     safeMinorNames.length > 0
       ? `api/minors/${catalogYear}/${safeMinorNames.join(",")}`

--- a/packages/frontend/hooks/useMinor.ts
+++ b/packages/frontend/hooks/useMinor.ts
@@ -1,35 +1,36 @@
-import useSWR, { SWRResponse } from "swr";
 import { API } from "@graduate/api-client";
 import { Minor } from "@graduate/common";
 import { AxiosError } from "axios";
+import useSWR from "swr";
 
-type MinorResponse = Omit<
-  SWRResponse<Minor, AxiosError | Error>,
-  "data" | "mutate"
->;
-
-type MinorReturn = MinorResponse & {
-  minor?: Minor;
+type MinorReturn = {
+  minors: Minor[];
   isLoading: boolean;
+  error?: AxiosError | Error;
 };
 
-/**
- * Gets the major by the major name and year.
- *
- * @param catalogYear
- * @param minorName   The name of the major, ex: "Computer Science, BSCS".
- */
-export function useMinor(catalogYear: number, minorName: string): MinorReturn {
-  const key = `api/minor/${catalogYear}/${minorName}`;
+export function useMinor(
+  catalogYear: number,
+  minorNames?: string[]
+): MinorReturn {
+  if (!minorNames) {
+    minorNames = [];
+  }
+  const key =
+    minorNames.length > 0
+      ? `api/minors/${catalogYear}/${minorNames?.join(",")}`
+      : null;
 
-  const { data, ...rest } = useSWR(
-    key,
-    async () => await API.minors.get(catalogYear, minorName)
-  );
+  const { data, error } = useSWR(key, async () => {
+    const promises = minorNames.map((minorName) =>
+      API.minors.get(catalogYear, minorName)
+    );
+    return Promise.all(promises);
+  });
 
   return {
-    ...rest,
-    minor: data,
-    isLoading: !data && !rest.error,
+    minors: data || [],
+    isLoading: !data && !error,
+    error,
   };
 }

--- a/packages/frontend/hooks/useMinor.ts
+++ b/packages/frontend/hooks/useMinor.ts
@@ -30,7 +30,7 @@ export function useMinor(
 
   return {
     minors: data || [],
-    isLoading: !data && !error,
+    isLoading: key !== null && !data && !error,
     error,
   };
 }

--- a/packages/frontend/hooks/useMinor.ts
+++ b/packages/frontend/hooks/useMinor.ts
@@ -13,16 +13,14 @@ export function useMinor(
   catalogYear: number,
   minorNames?: string[]
 ): MinorReturn {
-  if (!minorNames) {
-    minorNames = [];
-  }
+  const safeMinorNames = minorNames || [];
   const key =
-    minorNames.length > 0
-      ? `api/minors/${catalogYear}/${minorNames?.join(",")}`
+    safeMinorNames.length > 0
+      ? `api/minors/${catalogYear}/${safeMinorNames.join(",")}`
       : null;
 
   const { data, error } = useSWR(key, async () => {
-    const promises = minorNames?.map((minorName) =>
+    const promises = safeMinorNames.map((minorName) =>
       API.minors.get(catalogYear, minorName)
     );
     return Promise.all(promises);

--- a/packages/frontend/hooks/useMinor.ts
+++ b/packages/frontend/hooks/useMinor.ts
@@ -22,7 +22,7 @@ export function useMinor(
       : null;
 
   const { data, error } = useSWR(key, async () => {
-    const promises = minorNames.map((minorName) =>
+    const promises = minorNames?.map((minorName) =>
       API.minors.get(catalogYear, minorName)
     );
     return Promise.all(promises);


### PR DESCRIPTION
# Description

Ticket containing the migration of minor: string to minors: string[] so a plan can have multiple minors. All schema files changed so there are no errors and the app can run normally with no errors in the console. Updated the edit and add plan modal to allow plans to be made with a combination of multiple majors and minors. 

The sidebar still is only showing the first major and minor in the plan, but the others are there we are just awaiting a design for the best way to showcase them.

Closes # (861)

## Type of change

Please tick the boxes that best match your changes.
This has migration changes and will eventually require a run of `yarn dev:migration:run` ONCE we merge the entirety of flexible-majors in.

# How Has This Been Tested?
<img width="412" height="585" alt="Screenshot 2025-09-20 at 8 18 02 PM" src="https://github.com/user-attachments/assets/54b1092f-094f-4bec-b135-22480b841076" />
<img width="1145" height="843" alt="Screenshot 2025-09-20 at 8 18 22 PM" src="https://github.com/user-attachments/assets/4e7357c3-be16-46ed-9dee-8eb1eaee26d9" />

