### PR TITLE
 [FEATURE] CTRL+[shortcut] to create new plan

### DIFF
--- a/packages/frontend/components/Plan/AddPlanModal.tsx
+++ b/packages/frontend/components/Plan/AddPlanModal.tsx
@@ -55,7 +55,7 @@ import {
 import { BlueButton } from "../Button";
 import { PlanInput, PlanSelect } from "../Form";
 import { HelperToolTip } from "../Help";
-import { IsGuestContext } from "../../pages/_app";
+import { IsGuestContext, NewPlanModalContext } from "../../pages/_app";
 import { GraduateToolTip } from "../GraduateTooltip";
 import { getLocalPlansLength } from "../../utils/plan/getLocalPlansLength";
 import { useTemplateCourses } from "../../hooks/useTemplateCourses";
@@ -71,6 +71,8 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
 }) => {
   const router = useRouter();
   const { onOpen, onClose: onCloseDisplay, isOpen } = useDisclosure();
+  const { isNewPlanModalOpen, setIsNewPlanModalOpen } =
+    useContext(NewPlanModalContext);
   const { supportedMajorsData, error: supportedMajorsError } =
     useSupportedMajors();
   const { supportedMinorsData, error: supportedMinorsError } =
@@ -128,6 +130,14 @@ export const AddPlanModal: React.FC<AddPlanModalProps> = ({
   useEffect(() => {
     setValue("useTemplate", false);
   }, [majorName, catalogYear, setValue]);
+
+  // handle keyboard shortcut modal opening
+  useEffect(() => {
+    if (isNewPlanModalOpen) {
+      onOpen();
+      setIsNewPlanModalOpen(false);
+    }
+  }, [isNewPlanModalOpen, onOpen, setIsNewPlanModalOpen]);
 
   if (!student) {
     return null;

--- a/packages/frontend/components/Shorcuts/ShortcutsProvider.tsx
+++ b/packages/frontend/components/Shorcuts/ShortcutsProvider.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from "react";
+import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
+import { useWindowSize } from "../../hooks";
+import { NewPlanModalContext } from "../../pages/_app";
+
+interface ShortcutsProviderProps {
+  children?: React.ReactNode;
+}
+
+export const ShortcutsProvider = ({ children }: ShortcutsProviderProps) => {
+  const { setIsNewPlanModalOpen } = useContext(NewPlanModalContext);
+  const { width } = useWindowSize();
+
+  const disableApp = width ? width <= 1100 : false;
+
+  useKeyboardShortcuts({
+    shortcuts: [
+      {
+        key: "N",
+        ctrlKey: true,
+        shiftKey: true,
+        callback: () => setIsNewPlanModalOpen(true),
+        // disable shortcuts when app is disabled
+        disabled: disableApp,
+      },
+      // we can add more shorcuts here in the future
+    ],
+    // by default disabled on landing + login pages
+    disabledRoutes: ["/", "/login"],
+  });
+
+  return <>{children}</>;
+};

--- a/packages/frontend/hooks/useKeyboardShortcuts.ts
+++ b/packages/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+interface KeyboardShortcut {
+  key: string;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  callback: () => void;
+  disabled?: boolean;
+}
+
+interface UseKeyboardShortcutsOptions {
+  shortcuts: KeyboardShortcut[];
+  disabledRoutes?: string[];
+}
+
+export const useKeyboardShortcuts = (
+  options: UseKeyboardShortcutsOptions
+): void => {
+  const { shortcuts, disabledRoutes = ["/"] } = options;
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const currentPath = router.asPath;
+      const isDisabledRoute = disabledRoutes.includes(currentPath);
+
+      if (isDisabledRoute) return;
+
+      shortcuts.forEach((shortcut) => {
+        if (shortcut.disabled) return;
+
+        const keyMatches =
+          event.key.toLowerCase() === shortcut.key.toLowerCase();
+        const ctrlMatches = (shortcut.ctrlKey ?? false) === event.ctrlKey;
+        const shiftMatches = (shortcut.shiftKey ?? false) === event.shiftKey;
+        const altMatches = (shortcut.altKey ?? false) === event.altKey;
+
+        if (keyMatches && ctrlMatches && shiftMatches && altMatches) {
+          event.preventDefault();
+          shortcut.callback();
+        }
+      });
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [shortcuts, disabledRoutes, router.asPath]);
+};

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -1,4 +1,10 @@
-import { Dispatch, SetStateAction, createContext, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  createContext,
+  useState,
+  useEffect,
+} from "react";
 import { ChakraProvider, Flex, Heading, Image, Text } from "@chakra-ui/react";
 import "@fontsource/montserrat-alternates";
 import type { AppProps } from "next/app";
@@ -22,6 +28,16 @@ export const IsGuestContext = createContext<IsGuestContextType>({
   setIsGuest: () => undefined,
 });
 
+interface NewPlanModalContextType {
+  isNewPlanModalOpen: boolean;
+  setIsNewPlanModalOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+export const NewPlanModalContext = createContext<NewPlanModalContextType>({
+  isNewPlanModalOpen: false,
+  setIsNewPlanModalOpen: () => undefined,
+});
+
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const { width } = useWindowSize();
@@ -29,6 +45,27 @@ function MyApp({ Component, pageProps }: AppProps) {
   const isLandingPage = router.asPath === "/";
   const disableApp = !isLandingPage && width && width <= 1100;
   const [isGuest, setIsGuest] = useState(false);
+
+  const [isNewPlanModalOpen, setIsNewPlanModalOpen] = useState(false);
+
+  // keyboard shortcut for new plan (ctrl+shift+n)
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        !isLandingPage &&
+        !disableApp &&
+        event.ctrlKey &&
+        event.shiftKey &&
+        event.key === "N"
+      ) {
+        console.log("Shortcut triggered!");
+        event.preventDefault();
+        setIsNewPlanModalOpen(true);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isLandingPage, disableApp]);
 
   return (
     <>
@@ -44,7 +81,11 @@ function MyApp({ Component, pageProps }: AppProps) {
         </Head>
         <ChakraProvider theme={theme}>
           <IsGuestContext.Provider value={{ isGuest, setIsGuest }}>
-            {disableApp ? <DisabledApp /> : <Component {...pageProps} />}
+            <NewPlanModalContext.Provider
+              value={{ isNewPlanModalOpen, setIsNewPlanModalOpen }}
+            >
+              {disableApp ? <DisabledApp /> : <Component {...pageProps} />}
+            </NewPlanModalContext.Provider>
           </IsGuestContext.Provider>
         </ChakraProvider>
         <ToastContainer position="bottom-right" />

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -1,10 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  createContext,
-  useState,
-  useEffect,
-} from "react";
+import { Dispatch, SetStateAction, createContext, useState } from "react";
 import { ChakraProvider, Flex, Heading, Image, Text } from "@chakra-ui/react";
 import "@fontsource/montserrat-alternates";
 import type { AppProps } from "next/app";
@@ -17,6 +11,7 @@ import { useWindowSize } from "../hooks";
 import { theme } from "../utils";
 import { ClientSideError } from "../components/Error/ClientSideError";
 import { Analytics } from "@vercel/analytics/react";
+import { ShortcutsProvider } from "../components/Shorcuts/ShortcutsProvider";
 
 interface IsGuestContextType {
   isGuest: boolean;
@@ -43,30 +38,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   const { width } = useWindowSize();
 
   const isLandingPage = router.asPath === "/";
-  const isLoginPage = router.asPath === "/login";
   const disableApp = !isLandingPage && width && width <= 1100;
   const [isGuest, setIsGuest] = useState(false);
-
   const [isNewPlanModalOpen, setIsNewPlanModalOpen] = useState(false);
-
-  // keyboard shortcut for new plan (ctrl+shift+n)
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        !isLandingPage &&
-        !disableApp &&
-        !isLoginPage &&
-        event.ctrlKey &&
-        event.shiftKey &&
-        event.key === "N"
-      ) {
-        event.preventDefault();
-        setIsNewPlanModalOpen(true);
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isLandingPage, isLoginPage, disableApp]);
 
   return (
     <>
@@ -85,7 +59,9 @@ function MyApp({ Component, pageProps }: AppProps) {
             <NewPlanModalContext.Provider
               value={{ isNewPlanModalOpen, setIsNewPlanModalOpen }}
             >
-              {disableApp ? <DisabledApp /> : <Component {...pageProps} />}
+              <ShortcutsProvider>
+                {disableApp ? <DisabledApp /> : <Component {...pageProps} />}
+              </ShortcutsProvider>
             </NewPlanModalContext.Provider>
           </IsGuestContext.Provider>
         </ChakraProvider>

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -43,6 +43,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const { width } = useWindowSize();
 
   const isLandingPage = router.asPath === "/";
+  const isLoginPage = router.asPath === "/login";
   const disableApp = !isLandingPage && width && width <= 1100;
   const [isGuest, setIsGuest] = useState(false);
 
@@ -54,18 +55,18 @@ function MyApp({ Component, pageProps }: AppProps) {
       if (
         !isLandingPage &&
         !disableApp &&
+        !isLoginPage &&
         event.ctrlKey &&
         event.shiftKey &&
         event.key === "N"
       ) {
-        console.log("Shortcut triggered!");
         event.preventDefault();
         setIsNewPlanModalOpen(true);
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isLandingPage, disableApp]);
+  }, [isLandingPage, isLoginPage, disableApp]);
 
   return (
     <>


### PR DESCRIPTION
# Description

Added a reusable keyboard shortcut system to handle shortcuts. Includes Ctrl+Shift+N to open the new plan modal so users don't have to click through the UI

- added **useKeyboardShortcuts** hook for reusable keyboard shortcut functionality
- added **ShortcutsProvider** component to manage global shortcuts
- created **NewPlanModalContext** for modal state management and added it to the **AddPlanModal** component

Closes #787 

## Type of change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?
- manually tested on home page by pressing ctrl+shift+n, new plan modal opens
- tested on landing/login page, pressing the shortcut does not trigger the modal
- tested on disabled screen, shortcut isn't triggered if app is disabled
- verified that clicking through the UI still works as expected 
- verified that a new plan can be created correctly after using the shortcut to open the modal
