### PR TITLE
Auto-check beta major when edit plan

### DIFF
--- a/packages/frontend/components/Plan/EditPlanModal.tsx
+++ b/packages/frontend/components/Plan/EditPlanModal.tsx
@@ -66,6 +66,7 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
   const router = useRouter();
   const { onOpen, onClose: onCloseDisplay, isOpen } = useDisclosure();
   const [isNoMajorSelected, setIsNoMajorSelected] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -122,6 +123,9 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
   const majorName = watch("major");
   const concentration = watch("concentration");
   const agreeToBetaMajor = watch("agreeToBetaMajor");
+  const editMajor = watch("major");
+  const currentMajor = plan.major;
+  const isMajorChanged = currentMajor != editMajor;
 
   const yearSupportedMajors =
     supportedMajorsData?.supportedMajors[catalogYear ?? 0];
@@ -347,20 +351,23 @@ export const EditPlanModal: React.FC<EditPlanModalProps> = ({ plan }) => {
                       isSearchable
                       useFuzzySearch
                     />
-                    {majorName && !isValidatedMajor && (
-                      <Flex alignItems="center">
-                        <Checkbox
-                          mr="md"
-                          {...register("agreeToBetaMajor", {
-                            required: "You must agree to continue",
-                          })}
-                        />
-                        <Text>
-                          I understand that I am selecting a beta major and that
-                          the requirements may not be accurate.
-                        </Text>
-                      </Flex>
-                    )}
+                    {editMajor &&
+                      isMajorChanged &&
+                      majorName &&
+                      !isValidatedMajor && (
+                        <Flex alignItems="center">
+                          <Checkbox
+                            mr="md"
+                            {...register("agreeToBetaMajor", {
+                              required: "You must agree to continue",
+                            })}
+                          />
+                          <Text>
+                            I understand that I am selecting a beta major and
+                            that the requirements may not be accurate.
+                          </Text>
+                        </Flex>
+                      )}
                   </>
                 )}
               </VStack>


### PR DESCRIPTION
# Description

This change hides the "I understand I'm signing up for a beta major..." checkbox until the user changes the major. 

Closes #864 

## Type of change

Please tick the boxes that best match your changes.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This requires a run of `yarn install`
- [ ] This has migration changes and requires a run of `yarn dev:migration:run`

# How Has This Been Tested?


https://github.com/user-attachments/assets/c947a1d5-4087-455d-a855-3d250306ff70


# Checklist:

- [ ] I have run the production builds in docker for the frontend/backend and ensure things run fine. Check README of repo on how to run if not sure.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I've run the end to end tests
- [ ] Any dependent changes have been merged and published in downstream modules
